### PR TITLE
Fix equity calculation in backtest environment

### DIFF
--- a/tests/test_backtest_env.py
+++ b/tests/test_backtest_env.py
@@ -90,5 +90,7 @@ def test_use_log_reward():
     env_log = make_env([1, 2, 3], use_log_reward=True)
     last_log = run_actions(env_log, [1, 2])
     assert last_lin["equity"] == pytest.approx(0.5)
-    assert last_log["equity"] == pytest.approx(np.log1p(0.5))
+    assert last_log["equity"] == pytest.approx(0.5)
+    assert last_lin["reward"] == pytest.approx(0.5)
+    assert last_log["reward"] == pytest.approx(np.log1p(0.5))
 


### PR DESCRIPTION
## Summary
- compute equity as realized PnL plus unrealized PnL and derive reward from equity change
- default price column set to lowercase to match test fixtures
- adjust log-reward test to check reward while keeping equity identical

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b20a8f5f60832ebeda58468dbafc05