### PR TITLE
feat: add normalization utilities

### DIFF
--- a/scr/__init__.py
+++ b/scr/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for reinforcement learning tools."""

--- a/scr/normalisation.py
+++ b/scr/normalisation.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+import numpy as np
+
+
+@dataclass
+class NormalizationStats:
+    """Compute statistics and apply feature-wise normalization.
+
+    Parameters
+    ----------
+    kind:
+        Normalization strategy. Supported values:
+        ``'zscore'`` (mean/std), ``'minmax'`` (range), ``'robust'``
+        (median/IQR).
+    eps:
+        Small constant to avoid division by zero.
+    """
+
+    kind: Literal["zscore", "minmax", "robust"] = "zscore"
+    eps: float = 1e-8
+    imputer_mean: Optional[np.ndarray] = None
+    mean: Optional[np.ndarray] = None
+    std: Optional[np.ndarray] = None
+    min_: Optional[np.ndarray] = None
+    max_: Optional[np.ndarray] = None
+    q1: Optional[np.ndarray] = None
+    q3: Optional[np.ndarray] = None
+    median: Optional[np.ndarray] = None
+
+    def fit(self, X_train: np.ndarray) -> "NormalizationStats":
+        """Fit normalization statistics on training data."""
+        Xf = X_train.astype(np.float32, copy=True)
+        Xf[~np.isfinite(Xf)] = np.nan
+        self.imputer_mean = np.nanmean(Xf, axis=0)
+        self.imputer_mean = np.where(
+            np.isfinite(self.imputer_mean), self.imputer_mean, 0.0
+        ).astype(np.float32)
+        Xc = self._impute(X_train)
+        if self.kind == "zscore":
+            self.mean = Xc.mean(axis=0)
+            self.std = Xc.std(axis=0) + self.eps
+        elif self.kind == "minmax":
+            self.min_ = Xc.min(axis=0)
+            self.max_ = Xc.max(axis=0)
+        elif self.kind == "robust":
+            self.q1 = np.percentile(Xc, 25, axis=0)
+            self.q3 = np.percentile(Xc, 75, axis=0)
+            self.median = np.median(Xc, axis=0)
+            self.std = (self.q3 - self.q1) + self.eps
+        else:
+            raise ValueError("Unknown norm kind")
+        return self
+
+    def _impute(self, X: np.ndarray) -> np.ndarray:
+        """Replace non-finite values with column means."""
+        X = X.astype(np.float32, copy=True)
+        bad = ~np.isfinite(X)
+        if bad.any():
+            col = np.nonzero(bad)[1]
+            X[bad] = self.imputer_mean[col]
+        return X
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        """Apply normalization to an array."""
+        X = self._impute(X)
+        if self.kind == "zscore":
+            return (X - self.mean) / self.std
+        if self.kind == "minmax":
+            return (X - self.min_) / ((self.max_ - self.min_) + self.eps)
+        if self.kind == "robust":
+            return (X - self.median) / self.std
+        raise ValueError("Unknown norm kind")

--- a/tests/test_normalisation.py
+++ b/tests/test_normalisation.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from scr.normalisation import NormalizationStats
+
+
+def test_zscore_normalisation():
+    X = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
+    norm = NormalizationStats(kind="zscore").fit(X)
+    Xt = norm.transform(X)
+    assert np.allclose(Xt.mean(axis=0), 0.0, atol=1e-7)
+    assert np.allclose(Xt.std(axis=0), 1.0, atol=1e-7)
+
+
+def test_minmax_normalisation():
+    X = np.array([[0, 1], [2, 3], [4, 5]], dtype=float)
+    norm = NormalizationStats(kind="minmax").fit(X)
+    Xt = norm.transform(X)
+    assert np.allclose(Xt.min(axis=0), 0.0)
+    assert np.allclose(Xt.max(axis=0), 1.0)
+
+
+def test_robust_normalisation():
+    X = np.array([[0, 1], [2, 3], [4, 5]], dtype=float)
+    norm = NormalizationStats(kind="robust").fit(X)
+    Xt = norm.transform(X)
+    assert np.allclose(np.median(Xt, axis=0), 0.0)
+    q1 = np.percentile(Xt, 25, axis=0)
+    q3 = np.percentile(Xt, 75, axis=0)
+    assert np.allclose(q3 - q1, 1.0)
+
+
+def test_imputation_removes_nans():
+    X_train = np.array([[1, np.nan], [3, 4]], dtype=float)
+    norm = NormalizationStats(kind="zscore").fit(X_train)
+    X = np.array([[np.nan, 5]], dtype=float)
+    Xt = norm.transform(X)
+    assert np.all(np.isfinite(Xt))


### PR DESCRIPTION
## Summary
- add `NormalizationStats` for z-score, min-max, and robust scaling
- ensure missing values are imputed with column means
- cover normalization behaviors with unit tests

## Testing
- `pytest tests/test_normalisation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b22b34720c832ebe490983090edcd1