### PR TITLE
Add helpers for model logits prediction and aligned backtesting

### DIFF
--- a/scr/train_eval.py
+++ b/scr/train_eval.py
@@ -739,6 +739,19 @@ def materialize_metrics(d: dict) -> dict:
     return out
 
 
+def predict_logits_dataset(model: keras.Model, ds: tf.data.Dataset) -> np.ndarray:
+    """Collect raw model logits over a dataset."""
+
+    logits_list = []
+    for batch in ds:
+        xb, *_ = _unpack_batch(batch)
+        logits = model(xb, training=False)
+        logits_list.append(logits.numpy())
+    if not logits_list:
+        return np.empty((0, NUM_CLASSES), dtype=np.float32)
+    return np.concatenate(logits_list, axis=0)
+
+
 __all__ = [
     "CosineWithWarmup",
     "OneCycleLR",
@@ -750,5 +763,6 @@ __all__ = [
     "oracle_expected_return_batch",
     "evaluate_dataset",
     "materialize_metrics",
+    "predict_logits_dataset",
 ]
 

--- a/tests/test_backtest_env.py
+++ b/tests/test_backtest_env.py
@@ -7,6 +7,7 @@ import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from scr.backtest_env import BacktestEnv, EnvConfig
+from scr.backtest_env import run_backtest_with_logits
 
 
 def make_env(prices, **cfg_kwargs):
@@ -143,4 +144,13 @@ def test_vector_action_with_mask_argmax():
     logits = [-1.0, 2.0, 5.0, 9.0]  # max на индексе 3, но он замаскирован → должен выбрать Open (1)
     _, _, _, info = env.step(logits)
     assert info["position"] in (0, 1)
+
+
+def test_run_backtest_with_logits_executes_trade():
+    df = make_df(4, start=1.0, step=1.0)
+    logits = np.array([[0.0, 5.0, 0.0, 0.0], [0.0, 0.0, 5.0, 0.0]])
+    indices = np.array([1, 2])
+    env = run_backtest_with_logits(df, logits, indices)
+    log = env.logs()
+    assert log.iloc[-1]["equity"] == pytest.approx((4 - 3) / 3)
 

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -117,3 +117,12 @@ def test_extract_features_excludes_Q_Mask_A_and_respects_drop():
     assert cols == ["feat1"] and X.shape == (3, 1)
 
 
+def test_fit_transform_returns_indices():
+    df = _make_df(20)
+    builder = DatasetBuilderForYourColumns(seq_len=3, norm="none", splits=(0.7, 0.15, 0.15))
+    splits = builder.fit_transform(df, return_indices=True)
+    Xte, _, _, _, _, _, idx = splits["test"]
+    assert idx.shape[0] == Xte.shape[0]
+    assert idx[0] == 19
+
+

--- a/tests/test_train_eval.py
+++ b/tests/test_train_eval.py
@@ -19,6 +19,7 @@ from scr.train_eval import (
     expected_return_metric,
     materialize_metrics,
     validate_one_epoch,
+    predict_logits_dataset,
 )
 from scr.dataset_builder import NUM_CLASSES
 
@@ -151,4 +152,18 @@ def test_materialize_metrics():
     out = materialize_metrics(metrics)
     assert out["a"] == 1.0
     assert out["b"] == [1, 2]
+
+
+def test_predict_logits_dataset():
+    model = DummyModel()
+    sig = (
+        tf.TensorSpec([None, 5], tf.float32),
+        (
+            tf.TensorSpec([None, 3], tf.float32),
+            tf.TensorSpec([None, 3], tf.float32),
+        ),
+    )
+    ds = tf.data.Dataset.from_generator(lambda: _ds_no_w(num_classes=3), output_signature=sig)
+    logits = predict_logits_dataset(model, ds)
+    assert logits.shape[1] == 3
 


### PR DESCRIPTION
## Summary
- allow dataset builder to optionally return original row indices for windows
- add `predict_logits_dataset` for collecting logits from a `tf.data.Dataset`
- introduce `run_backtest_with_logits` to simulate trades aligned with data

## Testing
- `pytest tests/test_dataset_builder.py tests/test_train_eval.py tests/test_backtest_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37f1ff214832eb021b47b61a6e67a