### PR TITLE
Align action ordering between Q-labels and backtest environment

### DIFF
--- a/tests/test_backtest_env.py
+++ b/tests/test_backtest_env.py
@@ -36,20 +36,20 @@ def run_actions(env, actions, reset=True):
 
 def test_equity_realized_no_fee():
     env = make_env([1, 2, 3])
-    last = run_actions(env, [1, 2])
+    last = run_actions(env, [0, 1])
     assert last["equity"] == pytest.approx(last["realized_pnl"])
 
 
 def test_equity_realized_with_fee_long():
     env = make_env([1, 2, 3], fee=0.1)
-    last = run_actions(env, [1, 2])
+    last = run_actions(env, [0, 1])
     assert last["equity"] == pytest.approx(0.0)
     assert last["realized_pnl"] == pytest.approx(0.0)
 
 
 def test_equity_realized_with_fee_short():
     env = make_env([3, 2, 1], mode=-1, fee=0.1)
-    last = run_actions(env, [1, 2])
+    last = run_actions(env, [0, 1])
     assert last["equity"] == pytest.approx(0.2)
     assert last["realized_pnl"] == pytest.approx(0.2)
 
@@ -64,7 +64,7 @@ def parse_report(report: str) -> dict:
 
 def test_metrics_report():
     env = make_env([1, 2, 3, 4, 1])
-    run_actions(env, [1, 2, 1, 2])
+    run_actions(env, [0, 1, 0, 1])
     metrics = parse_report(env.metrics_report())
     assert float(metrics["Win rate"].rstrip("%")) == pytest.approx(50.0)
     assert float(metrics["Profit factor"]) == pytest.approx(2 / 3, rel=1e-3)
@@ -74,22 +74,22 @@ def test_metrics_report():
 def test_time_penalty():
     env = make_env([1, 1, 1], time_penalty=0.1)
     env.reset()
-    env.step(1)  # open
-    last = run_actions(env, [3], reset=False)  # hold one step
+    env.step(0)  # open
+    last = run_actions(env, [2], reset=False)  # hold one step
     assert last["equity"] == pytest.approx(-0.1)
 
 
 def test_hold_penalty():
     env = make_env([1, 1], hold_penalty=0.05)
-    last = run_actions(env, [0])
+    last = run_actions(env, [3])
     assert last["equity"] == pytest.approx(-0.05)
 
 
 def test_use_log_reward():
     env_lin = make_env([1, 2, 3])
-    last_lin = run_actions(env_lin, [1, 2])
+    last_lin = run_actions(env_lin, [0, 1])
     env_log = make_env([1, 2, 3], use_log_reward=True)
-    last_log = run_actions(env_log, [1, 2])
+    last_log = run_actions(env_log, [0, 1])
     assert last_lin["equity"] == pytest.approx(0.5)
     assert last_log["equity"] == pytest.approx(0.5)
     assert last_lin["reward"] == pytest.approx(0.5)
@@ -110,12 +110,12 @@ def test_no_index_error_after_done():
     # Совершаем ровно max_steps шагов
     done = False
     for _ in range(cfg.max_steps):
-        _, _, done, _ = env.step(0)  # Wait
+        _, _, done, _ = env.step(3)  # Wait
     assert done is True
 
     # Доп. шаг после done не должен падать и должен оставаться done=True
     try:
-        _, r, d, _ = env.step(0)
+        _, r, d, _ = env.step(3)
     except IndexError:
         pytest.fail("IndexError after done")
     assert d is True
@@ -129,8 +129,8 @@ def test_log_reward_no_nan_on_large_negative():
                     use_log_reward=True, time_penalty=0.0, hold_penalty=0.0)
     env = BacktestEnv(df, feature_cols=["feat"], cfg=cfg)
 
-    env.step(1)  # Open long
-    obs, reward, done, info = env.step(3)  # Hold → сильный минус
+    env.step(0)  # Open long
+    obs, reward, done, info = env.step(2)  # Hold → сильный минус
     assert np.isfinite(reward), "reward should be finite with log reward clipping"
 
 def test_vector_action_with_mask_argmax():
@@ -140,15 +140,15 @@ def test_vector_action_with_mask_argmax():
         max_steps=10**9, reward_scale=1.0,
         use_log_reward=False, time_penalty=0.0, hold_penalty=0.0
     ))
-    # На старте позиция 0 → валидны только [Wait, Open]
-    logits = [-1.0, 2.0, 5.0, 9.0]  # max на индексе 3, но он замаскирован → должен выбрать Open (1)
+    # На старте позиция 0 → валидны только [Open, Wait]
+    logits = [5.0, -1.0, 9.0, -5.0]  # max на индексе 2, но он замаскирован → должен выбрать Open (0)
     _, _, _, info = env.step(logits)
     assert info["position"] in (0, 1)
 
 
 def test_run_backtest_with_logits_executes_trade():
     df = make_df(4, start=1.0, step=1.0)
-    logits = np.array([[0.0, 5.0, 0.0, 0.0], [0.0, 0.0, 5.0, 0.0]])
+    logits = np.array([[5.0, 0.0, 0.0, 0.0], [0.0, 5.0, 0.0, 0.0]])
     indices = np.array([1, 2])
     env = run_backtest_with_logits(df, logits, indices)
     log = env.logs()


### PR DESCRIPTION
## Summary
- Align BacktestEnv actions with Q-label ordering (Open=0, Close=1, Hold=2, Wait=3)
- Adjust default fallbacks, masks, and helper to respect new order
- Update unit tests for new action mapping

## Testing
- `pytest tests/test_backtest_env.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4218c5de4832eb8216b12509b269d