### PR TITLE
Expose position column and allow A_* in visualisation

### DIFF
--- a/scr/q_labels_matching.py
+++ b/scr/q_labels_matching.py
@@ -482,6 +482,8 @@ def soft_signal_labels_gaussian(
     * Размываем только Open/Close; Hold/Wait — дополняют вероятности до 1.
     * В позиции базовая метка = Hold, однако MAE-штраф уменьшает вес Hold
       в пользу Close пропорционально глубине просадки.
+    * В результате добавляется колонка ``Pos`` — смоделированная позиция
+      (one-side) для дальнейшей визуализации.
     """
     need = {'Open', 'High', 'Low', 'Signal_Rule'}
     miss = need - set(df.columns)
@@ -552,6 +554,7 @@ def soft_signal_labels_gaussian(
     a_hold[mask] /= total[mask]
     a_wait[mask] /= total[mask]
 
+    out["Pos"] = pos.astype(np.int8)
     out["A_Open"] = a_open.astype(np.float32)
     out["A_Close"] = a_close.astype(np.float32)
     out["A_Hold"] = a_hold.astype(np.float32)

--- a/scr/visualisation.py
+++ b/scr/visualisation.py
@@ -120,25 +120,24 @@ def plot_enriched_actions_one_side(
     indicators_panels: dict | None = None,
     assume_exec_next_bar: bool = True,
 ) -> None:
-    """Plot price with strategy signals and best actions based on Q labels.
+    """Plot price with strategy signals and best actions.
 
-    ``enriched_df`` must contain columns:
-    ['Open','High','Low','Close','Pos','Q_Open','Q_Close','Q_Hold','Q_Wait'].
+    ``enriched_df`` must contain price columns and ``Pos`` plus either
+    Q-labels (``Q_*``) or action probabilities (``A_*``).
     """
-    need = {
-        "Open",
-        "High",
-        "Low",
-        "Close",
-        "Pos",
-        "Q_Open",
-        "Q_Close",
-        "Q_Hold",
-        "Q_Wait",
-    }
-    miss = need - set(enriched_df.columns)
+    cols = set(enriched_df.columns)
+    need_base = {"Open", "High", "Low", "Close", "Pos"}
+    miss = need_base - cols
     if miss:
         raise ValueError(f"missing columns: {sorted(miss)}")
+
+    need_q = {"Q_Open", "Q_Close", "Q_Hold", "Q_Wait"}
+    need_a = {"A_Open", "A_Close", "A_Hold", "A_Wait"}
+    has_q = need_q.issubset(cols)
+    has_a = need_a.issubset(cols)
+    if not (has_q or has_a):
+        raise ValueError("missing columns: Q_* or A_*")
+    prefix = "Q_" if has_q else "A_"
 
     if end is None:
         end = len(enriched_df)
@@ -259,10 +258,10 @@ def plot_enriched_actions_one_side(
         _candles(ax_actions, t, o, h, l, c, alpha=0.35)
         ax_actions.grid(alpha=0.25)
 
-        q_open = df["Q_Open"].to_numpy(float)
-        q_close = df["Q_Close"].to_numpy(float)
-        q_hold = df["Q_Hold"].to_numpy(float)
-        q_wait = df["Q_Wait"].to_numpy(float)
+        q_open = df[f"{prefix}Open"].to_numpy(float)
+        q_close = df[f"{prefix}Close"].to_numpy(float)
+        q_hold = df[f"{prefix}Hold"].to_numpy(float)
+        q_wait = df[f"{prefix}Wait"].to_numpy(float)
 
         qs = np.vstack(
             [

--- a/tests/test_q_labels.py
+++ b/tests/test_q_labels.py
@@ -284,6 +284,11 @@ def test_soft_labels_gaussian_blur_and_normalisation():
     sums = out[['A_Open', 'A_Close', 'A_Hold', 'A_Wait']].sum(axis=1)
     np.testing.assert_allclose(sums, 1.0, rtol=1e-7)
 
+    # Смоделированная позиция доступна
+    assert 'Pos' in out.columns
+    expected_pos = np.array([0, 0, 1, 1, 0], dtype=np.int8)
+    np.testing.assert_array_equal(out['Pos'].to_numpy(np.int8), expected_pos)
+
 
 def test_soft_labels_mae_penalty_shifts_to_close():
     """MAE-штраф увеличивает вес Close относительно Hold."""
@@ -296,3 +301,8 @@ def test_soft_labels_mae_penalty_shifts_to_close():
 
     # t=2: в позиции и в просадке, вес Close должен вырасти
     assert out_pen.loc[2, 'A_Close'] > out_nopen.loc[2, 'A_Close']
+
+    # Позиция совпадает с ожидаемой
+    assert 'Pos' in out_pen.columns
+    expected_pos = np.array([0, 1, 1, 1, 1, 0], dtype=np.int8)
+    np.testing.assert_array_equal(out_pen['Pos'].to_numpy(np.int8), expected_pos)

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -30,3 +30,21 @@ def test_indicators_panels_accepts_series(monkeypatch):
         df, indicators_panels={"ADX": df["ADX_14"]}, start=0, end=len(df)
     )
 
+
+def test_plot_with_action_labels(monkeypatch):
+    monkeypatch.setattr("matplotlib.pyplot.show", lambda: None)
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2, 3],
+            "High": [1, 2, 3],
+            "Low": [1, 2, 3],
+            "Close": [1, 2, 3],
+            "Pos": [0, 0, 0],
+            "A_Open": [0.5, 0.2, 0.1],
+            "A_Close": [0.2, 0.3, 0.4],
+            "A_Hold": [0.2, 0.3, 0.3],
+            "A_Wait": [0.1, 0.2, 0.2],
+        }
+    )
+    plot_enriched_actions_one_side(df, start=0, end=len(df))
+


### PR DESCRIPTION
## Summary
- add `Pos` column to `soft_signal_labels_gaussian` for downstream plots
- allow `plot_enriched_actions_one_side` to work with either `Q_*` or `A_*` columns
- cover new behavior with unit tests

## Testing
- `pytest tests/test_q_labels.py::test_soft_labels_gaussian_blur_and_normalisation tests/test_q_labels.py::test_soft_labels_mae_penalty_shifts_to_close tests/test_visualisation.py::test_indicators_panels_accepts_series tests/test_visualisation.py::test_plot_with_action_labels -q`


------
https://chatgpt.com/codex/tasks/task_e_68b447dd7c14832ea45bda0cca461f32