### PR TITLE
Fix MAE penalty for Wait action in soft labels

### DIFF
--- a/scr/q_labels_matching.py
+++ b/scr/q_labels_matching.py
@@ -561,7 +561,7 @@ def soft_signal_labels_gaussian(
 
             if flat[t]:
                 if t == 0 or inpos[t - 1]:
-                    entry = entry_px[t]
+                    entry = Open[t]
                     worst_w = High[t] if side_long else Low[t]
                 else:
                     if side_long:
@@ -569,9 +569,9 @@ def soft_signal_labels_gaussian(
                     else:
                         worst_w = min(worst_w, Low[t])
                 if side_long:
-                    mae_w[t] = entry / worst_w - 1.0 
-                else:
                     mae_w[t] = worst_w / entry - 1.0
+                else:
+                    mae_w[t] = entry / worst_w - 1.0
             else:
                 mae_w[t] = 0.0
 

--- a/tests/test_q_labels.py
+++ b/tests/test_q_labels.py
@@ -318,3 +318,15 @@ def test_soft_labels_mae_penalty_shifts_to_close():
     assert 'Pos' in out_pen.columns
     expected_pos = np.array([0, 1, 1, 1, 1, 0], dtype=np.int8)
     np.testing.assert_array_equal(out_pen['Pos'].to_numpy(np.int8), expected_pos)
+
+
+def test_soft_labels_mae_penalty_shifts_to_open():
+    """MAE-штраф уменьшает вес Wait и увеличивает вес Open на растущем рынке."""
+    open_px = np.array([100., 110., 120., 130., 140.])
+    df = _mk_df(open_px, sig=np.zeros_like(open_px))
+
+    out_pen = soft_signal_labels_gaussian(df, blur_window=1, blur_sigma=1.0, mae_lambda=0.5)
+    out_nopen = soft_signal_labels_gaussian(df, blur_window=1, blur_sigma=1.0, mae_lambda=0.0)
+
+    assert out_pen.loc[1, 'A_Open'] > out_nopen.loc[1, 'A_Open']
+    assert out_pen.loc[1, 'A_Wait'] < out_nopen.loc[1, 'A_Wait']


### PR DESCRIPTION
## Summary
- correct MAE penalty for Wait action using high/low excursion from current open
- add regression test ensuring MAE penalty shifts weight from Wait to Open on uptrend

## Testing
- `pytest tests/test_q_labels.py::test_soft_labels_gaussian_blur_and_normalisation -q`
- `pytest tests/test_q_labels.py::test_soft_labels_mae_penalty_shifts_to_close -q`
- `pytest tests/test_q_labels.py::test_soft_labels_mae_penalty_shifts_to_open -q`
- `pytest tests/test_q_labels.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4be124134832e97fb693e0955a5a5