### PR TITLE
feat: split features and account inputs

### DIFF
--- a/scr/calibrate.py
+++ b/scr/calibrate.py
@@ -114,11 +114,12 @@ def _collect_validation_arrays(val_ds: tf.data.Dataset, num_classes: int) -> Tup
     """Materialise the validation dataset to NumPy arrays."""
 
     from .train_eval import _unpack_batch
-    Xb_list, Mb_list, Y_oh_list = [], [], []
+
+    Xb_list, Ab_list, Y_oh_list = [], [], []
     for batch in val_ds:
-        xb, mb, yb, *_ = _unpack_batch(batch)
+        xb, accb, _, yb, *_ = _unpack_batch(batch)
         xb_np = xb.numpy()
-        mb_np = mb.numpy()
+        acc_np = accb.numpy()
         yb_np = yb.numpy()
         if yb_np.ndim == 2 and yb_np.shape[1] == num_classes:
             y_onehot = yb_np.astype(np.float32)
@@ -126,13 +127,14 @@ def _collect_validation_arrays(val_ds: tf.data.Dataset, num_classes: int) -> Tup
             y_idx = np.squeeze(yb_np).astype(np.int64)
             y_onehot = np.eye(num_classes, dtype=np.float32)[y_idx]
         Xb_list.append(xb_np)
-        Mb_list.append(mb_np)
+        Ab_list.append(acc_np)
         Y_oh_list.append(y_onehot)
+
     Xb_val = np.concatenate(Xb_list, axis=0)
-    Mb_val = np.concatenate(Mb_list, axis=0)
+    Ab_val = np.concatenate(Ab_list, axis=0)
     Y_val_onehot = np.concatenate(Y_oh_list, axis=0)
     Y_val_int = Y_val_onehot.argmax(axis=1)
-    return Xb_val, Mb_val, Y_val_onehot, Y_val_int
+    return Xb_val, Ab_val, Y_val_onehot, Y_val_int
 
 
 def calibrate_model(
@@ -153,16 +155,16 @@ def calibrate_model(
     """
 
     num_classes = int(model.output_shape[-1])
-    Xb_val, Mb_val, Y_val_onehot, Y_val_int = _collect_validation_arrays(val_ds, num_classes)
+    Xb_val, Ab_val, Y_val_onehot, Y_val_int = _collect_validation_arrays(val_ds, num_classes)
 
     n = (Xb_val.shape[0] // batch_size) * batch_size
     Xb_val = Xb_val[:n]
-    Mb_val = Mb_val[:n]
+    Ab_val = Ab_val[:n]
     Y_val_onehot = Y_val_onehot[:n]
     Y_val_int = Y_val_int[:n]
 
-    has_mask = isinstance(model.input_shape, list) and len(model.input_shape) == 2
-    probe_inputs = (Xb_val[:batch_size], Mb_val[:batch_size]) if has_mask else Xb_val[:batch_size]
+    has_second = isinstance(model.input_shape, list) and len(model.input_shape) == 2
+    probe_inputs = (Xb_val[:batch_size], Ab_val[:batch_size]) if has_second else Xb_val[:batch_size]
     probe = model.predict(probe_inputs, batch_size=batch_size, verbose=0)
 
     def looks_like_probs(a: np.ndarray) -> bool:
@@ -174,10 +176,10 @@ def calibrate_model(
     is_probs = looks_like_probs(probe) if isinstance(probe, np.ndarray) else False
 
     inp_x = tf.keras.Input(shape=Xb_val.shape[1:], name="xb")
-    if has_mask:
-        inp_m = tf.keras.Input(shape=Mb_val.shape[1:], name="mb")
-        raw_out = model([inp_x, inp_m], training=False)
-        base_inputs = [inp_x, inp_m]
+    if has_second:
+        inp_a = tf.keras.Input(shape=Ab_val.shape[1:], name="acc")
+        raw_out = model([inp_x, inp_a], training=False)
+        base_inputs = [inp_x, inp_a]
     else:
         raw_out = model(inp_x, training=False)
         base_inputs = [inp_x]
@@ -198,7 +200,7 @@ def calibrate_model(
         metrics=[tf.keras.metrics.CategoricalCrossentropy(from_logits=True, name="nll")],
     )
 
-    inputs = (Xb_val, Mb_val) if has_mask else Xb_val
+    inputs = (Xb_val, Ab_val) if has_second else Xb_val
     val_np_ds = (
         tf.data.Dataset.from_tensor_slices((inputs, Y_val_onehot))
         .batch(batch_size, drop_remainder=True)
@@ -208,8 +210,8 @@ def calibrate_model(
     callbacks = [tf.keras.callbacks.EarlyStopping(monitor="nll", patience=5, restore_best_weights=True)]
     cal_model.fit(val_np_ds, epochs=100, verbose=0, callbacks=callbacks)
 
-    logits_before = base_logits_model.predict((Xb_val, Mb_val) if has_mask else Xb_val, batch_size=batch_size, verbose=0)
-    logits_after = cal_model.predict((Xb_val, Mb_val) if has_mask else Xb_val, batch_size=batch_size, verbose=0)
+    logits_before = base_logits_model.predict((Xb_val, Ab_val) if has_second else Xb_val, batch_size=batch_size, verbose=0)
+    logits_after = cal_model.predict((Xb_val, Ab_val) if has_second else Xb_val, batch_size=batch_size, verbose=0)
 
     probs_before = tf.nn.softmax(logits_before).numpy()
     probs_after = tf.nn.softmax(logits_after).numpy()

--- a/scr/optuna_tuner.py
+++ b/scr/optuna_tuner.py
@@ -15,6 +15,7 @@ def optimize_hyperparameters(
     val_ds: tf.data.Dataset,
     seq_len: int,
     feature_dim: int,
+    acc_dim: int,
     n_trials: int = 10,
     epochs: int = 10,
 ) -> Dict[str, object]:
@@ -53,6 +54,7 @@ def optimize_hyperparameters(
         model = build_stacked_residual_lstm(
             seq_len=seq_len,
             feature_dim=feature_dim,
+            account_dim=acc_dim,
             units_per_layer=units,
             dropout=dropout,
         )

--- a/tests/test_optuna_tuner.py
+++ b/tests/test_optuna_tuner.py
@@ -6,12 +6,13 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from scr.optuna_tuner import optimize_hyperparameters
 
 
-def _make_dataset(samples: int = 20, seq_len: int = 5, feature_dim: int = 3):
+def _make_dataset(samples: int = 20, seq_len: int = 5, feature_dim: int = 3, acc_dim: int = 2):
     x = tf.random.normal((samples, seq_len, feature_dim))
+    acc = tf.random.normal((samples, seq_len, acc_dim))
     y = tf.random.uniform((samples,), maxval=4, dtype=tf.int32)
     y = tf.one_hot(y, 4)
     m = tf.ones_like(y)
-    ds = tf.data.Dataset.from_tensor_slices((x, (y, m)))
+    ds = tf.data.Dataset.from_tensor_slices(((x, acc), (y, m)))
     return ds.batch(4)
 
 
@@ -19,7 +20,7 @@ def test_optuna_tune_runs():
     train_ds = _make_dataset()
     val_ds = _make_dataset()
     params = optimize_hyperparameters(
-        train_ds, val_ds, seq_len=5, feature_dim=3, n_trials=1, epochs=1
+        train_ds, val_ds, seq_len=5, feature_dim=3, acc_dim=2, n_trials=1, epochs=1
     )
     assert set(params) == {"units_per_layer", "dropout", "lr"}
     assert len(params["units_per_layer"]) == 3

--- a/tests/test_residual_lstm.py
+++ b/tests/test_residual_lstm.py
@@ -17,10 +17,11 @@ from scr.residual_lstm import (
 
 
 def test_model_output_shape_and_inputs():
-    model = build_stacked_residual_lstm(seq_len=5, feature_dim=3, units_per_layer=(4, 4))
-    assert len(model.inputs) == 1
+    model = build_stacked_residual_lstm(seq_len=5, feature_dim=3, account_dim=2, units_per_layer=(4, 4))
+    assert len(model.inputs) == 2
     x = tf.random.normal((2, 5, 3))
-    logits = model(x)
+    a = tf.random.normal((2, 5, 2))
+    logits = model([x, a])
     assert logits.shape == (2, 4)
 
 


### PR DESCRIPTION
## Summary
- allow DatasetBuilder to take explicit feature and account column lists and emit two input channels
- redesign residual LSTM, training utils, and calibration to handle features and account sequences independently
- extend tests and optuna tuner for dual-input architecture

## Testing
- `pytest tests/test_dataset_builder.py tests/test_residual_lstm.py tests/test_train_eval.py tests/test_optuna_tuner.py tests/test_integration_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b59c2b84f4832e8ec90f279424d75e