### PR TITLE
Use current-candle account vector with dense merge

### DIFF
--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -30,6 +30,7 @@ def _make_df(n: int = 20) -> pd.DataFrame:
         data[f"Mask_{a}"] = np.ones(n, dtype=np.float32)
     return pd.DataFrame(data)
 
+
 def df_from_WM(W, M, extra_cols=None):
     d = {}
     for i, a in enumerate(ACTIONS):
@@ -38,6 +39,7 @@ def df_from_WM(W, M, extra_cols=None):
     if extra_cols:
         d.update(extra_cols)
     return pd.DataFrame(d)
+
 
 def test_fit_transform_shapes():
     df = _make_df(30)
@@ -52,12 +54,13 @@ def test_fit_transform_shapes():
     Xtr, Atr, Ytr, Mtr, Wtr, Rtr, SWtr = splits["train"]
 
     assert Xtr.shape[1:] == (3, 2)
-    assert Atr.shape[1:] == (3, 2)
+    assert Atr.shape[1:] == (2,)
     assert Ytr.shape[1] == 4
     assert Mtr.shape == Ytr.shape
     assert Wtr.shape == Ytr.shape
     assert Rtr.shape[0] == Xtr.shape[0]
     assert SWtr is None
+
 
 def test_teacher_R_all_zero_mask_rows():
     W = np.array(
@@ -135,7 +138,7 @@ def test_window_segment_drops_windows_with_invalid_last_mask():
     Xw, Aw, Yw, Mw, Ww, Rw, SWw = _window_segment(
         X, A, Y, M, W, R, seq_len=2, stride=1, SW=None
     )
-    assert Xw.shape[0] == 1 and Aw.shape == (1, 2, 2)
+    assert Xw.shape[0] == 1 and Aw.shape == (1, 2)
     assert Yw.shape == (1, C) and Rw.shape == (1,)
 
 
@@ -201,5 +204,3 @@ def test_class_balance_weights_excludes_unused_rows():
 
     assert np.allclose(builder.invfreq_, expected_invfreq)
     assert np.allclose(SWtr, expected_sw)
-
-

--- a/tests/test_optuna_tuner.py
+++ b/tests/test_optuna_tuner.py
@@ -6,9 +6,11 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from scr.optuna_tuner import optimize_hyperparameters
 
 
-def _make_dataset(samples: int = 20, seq_len: int = 5, feature_dim: int = 3, acc_dim: int = 2):
+def _make_dataset(
+    samples: int = 20, seq_len: int = 5, feature_dim: int = 3, acc_dim: int = 2
+):
     x = tf.random.normal((samples, seq_len, feature_dim))
-    acc = tf.random.normal((samples, seq_len, acc_dim))
+    acc = tf.random.normal((samples, acc_dim))
     y = tf.random.uniform((samples,), maxval=4, dtype=tf.int32)
     y = tf.one_hot(y, 4)
     m = tf.ones_like(y)

--- a/tests/test_residual_lstm.py
+++ b/tests/test_residual_lstm.py
@@ -17,10 +17,12 @@ from scr.residual_lstm import (
 
 
 def test_model_output_shape_and_inputs():
-    model = build_stacked_residual_lstm(seq_len=5, feature_dim=3, account_dim=2, units_per_layer=(4, 4))
+    model = build_stacked_residual_lstm(
+        seq_len=5, feature_dim=3, account_dim=2, units_per_layer=(4, 4)
+    )
     assert len(model.inputs) == 2
     x = tf.random.normal((2, 5, 3))
-    a = tf.random.normal((2, 5, 2))
+    a = tf.random.normal((2, 2))
     logits = model([x, a])
     assert logits.shape == (2, 4)
 
@@ -35,7 +37,9 @@ def test_apply_action_mask_and_softmax():
 
 
 def test_masked_loss_and_accuracy_with_sample_weights():
-    logits = tf.math.log(tf.constant([[0.7, 0.2, 0.1], [0.1, 0.8, 0.1]], dtype=tf.float32))
+    logits = tf.math.log(
+        tf.constant([[0.7, 0.2, 0.1], [0.1, 0.8, 0.1]], dtype=tf.float32)
+    )
     mask = tf.constant([[1.0, 1.0, 0.0], [1.0, 0.0, 1.0]], dtype=tf.float32)
     y_true = tf.constant([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=tf.float32)
     sw = tf.constant([1.0, 2.0], dtype=tf.float32)
@@ -57,7 +61,7 @@ def test_masked_loss_and_accuracy_with_sample_weights():
     y_sum = y_masked.sum(axis=1, keepdims=True)
     y_norm = np.where(y_sum > 0, y_masked / np.maximum(y_sum, 1e-8), y_masked)
     per_sample = -(y_norm * np.log(np.maximum(probs, 1e-8))).sum(axis=1)
-    has_label = (y_sum.squeeze() > 0)
+    has_label = y_sum.squeeze() > 0
     per_sample = np.where(has_label, per_sample, 0.0)
     loss_exp = (per_sample * sw_np).sum() / (sw_np * has_label).sum()
 
@@ -82,7 +86,9 @@ def test_fp16_all_invalid_no_nan():
 
 
 def test_loss_denominator_uses_has_label():
-    logits = tf.math.log(tf.constant([[0.7, 0.1, 0.1, 0.1], [0.7, 0.1, 0.1, 0.1]], dtype=tf.float32))
+    logits = tf.math.log(
+        tf.constant([[0.7, 0.1, 0.1, 0.1], [0.7, 0.1, 0.1, 0.1]], dtype=tf.float32)
+    )
     y_true = tf.constant([[1, 0, 0, 0], [0, 1, 0, 0]], dtype=tf.float32)
     mask = tf.constant([[1, 1, 1, 1], [1, 0, 1, 1]], dtype=tf.float32)
     loss = masked_categorical_crossentropy(y_true, logits, mask)
@@ -91,7 +97,9 @@ def test_loss_denominator_uses_has_label():
 
 
 def test_accuracy_ignores_no_valid_label():
-    logits = tf.math.log(tf.constant([[0.7, 0.1, 0.1, 0.1], [0.0, 0.0, 0.0, 1.0]], dtype=tf.float32))
+    logits = tf.math.log(
+        tf.constant([[0.7, 0.1, 0.1, 0.1], [0.0, 0.0, 0.0, 1.0]], dtype=tf.float32)
+    )
     y_true = tf.constant([[1, 0, 0, 0], [0, 1, 0, 0]], dtype=tf.float32)
     mask = tf.constant([[1, 1, 1, 1], [1, 0, 1, 1]], dtype=tf.float32)
     acc = masked_accuracy(y_true, logits, mask)


### PR DESCRIPTION
## Summary
- slice account features to last timestep producing a 1‑D vector per window
- process account vector with dense+dropout and merge with LSTM branch
- adjust dataset builder, model, and tests for new account input shape

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5aeb913c8832ea6ad02adc980a021