### PR TITLE
Unify feature and account inputs into single tensor

### DIFF
--- a/scr/train_eval.py
+++ b/scr/train_eval.py
@@ -110,15 +110,15 @@ class OneCycleLR:
 
 def _unpack_batch(
     batch: Any,
-) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor | None, tf.Tensor | None, tf.Tensor | None]:
+) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor, tf.Tensor | None, tf.Tensor | None, tf.Tensor | None]:
     """Unpack batches produced by :func:`dataset_builder.build_tf_dataset`.
 
-    The dataset can provide ``((X, A), (Y, M))`` or with additional arrays
-    ``((X, A), (Y, M, W, R[, SW]))``.  The function returns
-    ``X, A, M, Y, W, R, SW`` where ``W``, ``R`` and ``SW`` may be ``None``.
+    The dataset can provide ``(X, (Y, M))`` or with additional arrays
+    ``(X, (Y, M, W, R[, SW]))``.  The function returns
+    ``X, M, Y, W, R, SW`` where ``W``, ``R`` and ``SW`` may be ``None``.
     """
 
-    (x, acc), rest = batch
+    x, rest = batch
     y, m, *extra = rest
     W = R = SW = None
     if extra:
@@ -141,7 +141,7 @@ def _unpack_batch(
                 SW = b
         else:
             W, R, SW = extra[:3]
-    return x, acc, m, y, W, R, SW
+    return x, m, y, W, R, SW
 
 
 def expected_return_metric(
@@ -261,13 +261,13 @@ def train_one_epoch(
     er_cnt = tf.zeros((), tf.float32)
 
     for batch in train_ds:
-        xb, accb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
+        xb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
 
         if lr_schedule is not None:
             optimizer.learning_rate.assign(lr_schedule(global_step))
 
         with tf.GradientTape() as tape:
-            logits = model([xb, accb], training=True)
+            logits = model(xb, training=True)
             loss = masked_categorical_crossentropy(yb, logits, mb, sample_w=SWb)
         grads = tape.gradient(loss, model.trainable_variables)
         optimizer.apply_gradients(zip(grads, model.trainable_variables))
@@ -316,8 +316,8 @@ def validate_one_epoch(model: keras.Model, val_ds: tf.data.Dataset):
     ic_batches = tf.zeros((), tf.float32)
 
     for batch in val_ds:
-        xb, accb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
-        logits = model([xb, accb], training=False)
+        xb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
+        logits = model(xb, training=False)
 
         loss = masked_categorical_crossentropy(yb, logits, mb, sample_w=SWb)
         acc = masked_accuracy(yb, logits, mb, sample_w=SWb)
@@ -582,8 +582,8 @@ def confusion_and_f1_on_dataset(model: keras.Model, ds: tf.data.Dataset):
     y_true = []
     y_pred = []
     for batch in ds:
-        xb, accb, mb, yb, _, _, _ = _unpack_batch(batch)
-        logits = model([xb, accb], training=False)
+        xb, mb, yb, _, _, _ = _unpack_batch(batch)
+        logits = model(xb, training=False)
         masked_logits = apply_action_mask(logits, mb)
         y_true.append(np.argmax(yb.numpy(), axis=1))
         y_pred.append(np.argmax(masked_logits.numpy(), axis=1))
@@ -668,8 +668,8 @@ def evaluate_dataset(model: keras.Model, ds: tf.data.Dataset):
     ic_batches = tf.zeros((), tf.float32)
 
     for batch in ds:
-        xb, accb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
-        logits = model([xb, accb], training=False)
+        xb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
+        logits = model(xb, training=False)
 
         loss = masked_categorical_crossentropy(yb, logits, mb, sample_w=SWb)
         acc = masked_accuracy(yb, logits, mb, sample_w=SWb)
@@ -746,8 +746,8 @@ def predict_logits_dataset(model: keras.Model, ds: tf.data.Dataset) -> np.ndarra
 
     logits_list = []
     for batch in ds:
-        xb, accb, *_ = _unpack_batch(batch)
-        logits = model([xb, accb], training=False)
+        xb, *_ = _unpack_batch(batch)
+        logits = model(xb, training=False)
         logits_list.append(logits.numpy())
     if not logits_list:
         return np.empty((0, NUM_CLASSES), dtype=np.float32)

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -51,10 +51,9 @@ def test_fit_transform_shapes():
         splits=(0.5, 0.25, 0.25),
     )
     splits = builder.fit_transform(df)
-    Xtr, Atr, Ytr, Mtr, Wtr, Rtr, SWtr = splits["train"]
+    Xtr, Ytr, Mtr, Wtr, Rtr, SWtr = splits["train"]
 
-    assert Xtr.shape[1:] == (3, 2)
-    assert Atr.shape[1:] == (2,)
+    assert Xtr.shape[1:] == (3, 4)
     assert Ytr.shape[1] == 4
     assert Mtr.shape == Ytr.shape
     assert Wtr.shape == Ytr.shape
@@ -135,10 +134,11 @@ def test_window_segment_drops_windows_with_invalid_last_mask():
     )
     R = np.arange(N, dtype=np.float32)
 
-    Xw, Aw, Yw, Mw, Ww, Rw, SWw = _window_segment(
-        X, A, Y, M, W, R, seq_len=2, stride=1, SW=None
+    Xall = np.concatenate([X, A], axis=1)
+    Xw, Yw, Mw, Ww, Rw, SWw = _window_segment(
+        Xall, Y, M, W, R, seq_len=2, stride=1, SW=None
     )
-    assert Xw.shape[0] == 1 and Aw.shape == (1, 2)
+    assert Xw.shape[0] == 1 and Xw.shape[2] == 4
     assert Yw.shape == (1, C) and Rw.shape == (1,)
 
 
@@ -166,7 +166,7 @@ def test_fit_transform_returns_indices():
         splits=(0.7, 0.15, 0.15),
     )
     splits = builder.fit_transform(df, return_indices=True)
-    Xte, Ate, _, _, _, _, _, idx = splits["test"]
+    Xte, _, _, _, _, _, idx = splits["test"]
     assert idx.shape[0] == Xte.shape[0]
     assert idx[0] == 19
 

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -52,14 +52,13 @@ def test_full_pipeline(tmp_path):
 
     model = build_stacked_residual_lstm(
         seq_len=5,
-        feature_dim=len(builder.feature_names),
-        account_dim=len(builder.account_names),
+        feature_dim=len(builder.feature_names) + len(builder.account_names),
         units_per_layer=(8, 8),
     )
 
     batch = next(iter(ds_tr.take(1)))
-    xb, accb, mb, yb, *_ = _unpack_batch(batch)
-    out = model([xb, accb], training=False)
+    xb, mb, yb, *_ = _unpack_batch(batch)
+    out = model(xb, training=False)
     assert out.shape == (xb.shape[0], NUM_CLASSES)
     assert np.isfinite(out.numpy()).all()
 
@@ -79,7 +78,6 @@ def test_full_pipeline(tmp_path):
         start=start,
         feature_cols=builder.feature_names,
         price_col="Close",
-        state_stats=builder.stats_account,
     )
     assert env.history
     log = env.logs()

--- a/tests/test_residual_lstm.py
+++ b/tests/test_residual_lstm.py
@@ -18,12 +18,11 @@ from scr.residual_lstm import (
 
 def test_model_output_shape_and_inputs():
     model = build_stacked_residual_lstm(
-        seq_len=5, feature_dim=3, account_dim=2, units_per_layer=(4, 4)
+        seq_len=5, feature_dim=5, units_per_layer=(4, 4)
     )
-    assert len(model.inputs) == 2
-    x = tf.random.normal((2, 5, 3))
-    a = tf.random.normal((2, 2))
-    logits = model([x, a])
+    assert len(model.inputs) == 1
+    x = tf.random.normal((2, 5, 5))
+    logits = model(x)
     assert logits.shape == (2, 4)
 
 

--- a/tests/test_train_eval.py
+++ b/tests/test_train_eval.py
@@ -26,7 +26,7 @@ from scr.dataset_builder import NUM_CLASSES
 
 class DummyModel(tf.keras.Model):
     def call(self, inputs, training=False):  # pragma: no cover - simple model
-        x, acc = inputs
+        x = inputs
         batch = tf.shape(x)[0]
         logits = tf.reshape(tf.constant([1.0, 0.5, -2.0]), [1, 3])
         return tf.tile(logits, [batch, 1])
@@ -35,52 +35,47 @@ class DummyModel(tf.keras.Model):
 def _ds_no_w(batch_size=4, batches=3, num_classes=3):
     for _ in range(batches):
         x = tf.zeros([batch_size, 5])
-        acc = tf.zeros([batch_size, 2])
         m = tf.ones([batch_size, num_classes])
         y = tf.one_hot(np.random.randint(0, num_classes, size=(batch_size,)), num_classes)
-        yield (x, acc), (y, m)
+        yield x, (y, m)
 
 
 def _ds_sw(batch_size=4, batches=3, num_classes=3):
     for _ in range(batches):
         x = tf.zeros([batch_size, 5])
-        acc = tf.zeros([batch_size, 2])
         m = tf.ones([batch_size, num_classes])
         y = tf.one_hot(np.random.randint(0, num_classes, size=(batch_size,)), num_classes)
         sw = tf.random.uniform([batch_size])
-        yield (x, acc), (y, m, sw)
+        yield x, (y, m, sw)
 
 
 def _ds_masked():
     x = tf.zeros([4, 5])
-    acc = tf.zeros([4, 2])
     m = tf.concat([tf.zeros([4, 1]), tf.ones([4, 2])], axis=1)
     y = tf.one_hot([1, 1, 2, 2], 3)
-    yield (x, acc), (y, m)
+    yield x, (y, m)
 
     
 def test_unpack_batch_with_sw():
     x = tf.zeros((2, 5, 3))
-    acc = tf.zeros((2, 5, 2))
     m = tf.ones((2, NUM_CLASSES))
     y = tf.zeros((2, NUM_CLASSES))
     W = tf.ones((2, NUM_CLASSES))
     R = tf.ones((2,))
     SW = tf.constant([0.5, 1.0], dtype=tf.float32)
-    batch = ((x, acc), (y, m, W, R, SW))
-    xb, accb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
-    assert xb is x and accb is acc and mb is m and yb is y
+    batch = (x, (y, m, W, R, SW))
+    xb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
+    assert xb is x and mb is m and yb is y
     assert Wb is W and Rb is R and SWb is SW
 
 
 def test_unpack_batch_sw_only():
     x = tf.zeros((2, 5, 3))
-    acc = tf.zeros((2, 5, 2))
     m = tf.ones((2, NUM_CLASSES))
     y = tf.zeros((2, NUM_CLASSES))
     SW = tf.constant([0.5, 1.0], dtype=tf.float32)
-    batch = ((x, acc), (y, m, SW))
-    xb, accb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
+    batch = (x, (y, m, SW))
+    xb, mb, yb, Wb, Rb, SWb = _unpack_batch(batch)
     assert Wb is None and Rb is None and SWb is SW
 
 
@@ -107,10 +102,7 @@ def test_expected_return_metric_simple():
 def test_validate_and_evaluate_no_w():
     model = DummyModel()
     sig = (
-        (
-            tf.TensorSpec([None, 5], tf.float32),
-            tf.TensorSpec([None, 2], tf.float32),
-        ),
+        tf.TensorSpec([None, 5], tf.float32),
         (
             tf.TensorSpec([None, 3], tf.float32),
             tf.TensorSpec([None, 3], tf.float32),
@@ -126,10 +118,7 @@ def test_validate_and_evaluate_no_w():
 def test_validate_and_evaluate_sw_only():
     model = DummyModel()
     sig = (
-        (
-            tf.TensorSpec([None, 5], tf.float32),
-            tf.TensorSpec([None, 2], tf.float32),
-        ),
+        tf.TensorSpec([None, 5], tf.float32),
         (
             tf.TensorSpec([None, 3], tf.float32),
             tf.TensorSpec([None, 3], tf.float32),
@@ -146,10 +135,7 @@ def test_validate_and_evaluate_sw_only():
 def test_confusion_f1_respects_mask(monkeypatch):
     model = DummyModel()
     sig = (
-        (
-            tf.TensorSpec([None, 5], tf.float32),
-            tf.TensorSpec([None, 2], tf.float32),
-        ),
+        tf.TensorSpec([None, 5], tf.float32),
         (
             tf.TensorSpec([None, 3], tf.float32),
             tf.TensorSpec([None, 3], tf.float32),
@@ -172,10 +158,7 @@ def test_materialize_metrics():
 def test_predict_logits_dataset():
     model = DummyModel()
     sig = (
-        (
-            tf.TensorSpec([None, 5], tf.float32),
-            tf.TensorSpec([None, 2], tf.float32),
-        ),
+        tf.TensorSpec([None, 5], tf.float32),
         (
             tf.TensorSpec([None, 3], tf.float32),
             tf.TensorSpec([None, 3], tf.float32),


### PR DESCRIPTION
## Summary
- Merge normalized features with pre-scaled account state so the dataset builder produces one sequence tensor
- Simplify residual LSTM, training/evaluation utilities, calibrator, and backtester to accept a single `(seq_len, feature_dim)` input
- Update tests and integration pipeline for new single-input workflow

## Testing
- `python -m pytest tests/test_dataset_builder.py::test_fit_transform_shapes tests/test_dataset_builder.py::test_window_segment_drops_windows_with_invalid_last_mask tests/test_residual_lstm.py::test_model_output_shape_and_inputs tests/test_train_eval.py::test_unpack_batch_with_sw tests/test_backtest_env.py::test_run_backtest_with_logits_executes_trade tests/test_integration_pipeline.py::test_full_pipeline -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6187c3db8832e8e05006c9a347572