### PR TITLE
Refactor Q label generation to TD-lambda only

### DIFF
--- a/scr/q_labels_matching.py
+++ b/scr/q_labels_matching.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
-from typing import Literal, Optional, Iterable
+
+from .backtest_env import BacktestEnv, EnvConfig
 
 """
 1. Execution @ next_open: решения на баре t исполняются на Open[t+1]. Это обеспечивает корректную причинность и реалистичный бэктест.
@@ -11,18 +12,11 @@ from typing import Literal, Optional, Iterable
 4. Единая временная опора для сравнения: в позиции сравниваем из t+1:
 Close = 0 (после закрытия прирост дальше равен нулю),
 Hold = Ret(t+1 → TGT). Это устраняет «ранний выход на полпути» из-за некорректных горизонтов и даёт стабильные решения.
-5. Три режима разметки:
-  mode='exit' — continuation до teacher-exit. Хорош для имитации конкретной стратегии выдержки/выхода.
-  mode='horizon' — фиксированный горизонт H. Классика supervised в финансах; стационарная цель без лейбл-ликинга по exit.
-  mode='tdlambda' — смесь n-step горизонтов (TF-style, TD-λ). Снижает дисперсию меток и согласуется с тем, как PPO/A2C обрабатывают возвраты.
-6. MAE-штраф (опционально):
-  если нужно «не сидеть в глубокой просадке», вводим штраф по Maximum Adverse Excursion на интервале удержания. 
-  Он уменьшает Q_Hold (и/или Q_Open) в абсолютной шкале, не ломая сопоставимость.
-
-7. Нормализация/клип:
-  допускается только глобальный winsorize/клип/робаст-скейл по train (единый для всех действий), чтобы стабилизировать обучение и 
+5. Разметка TD-λ: смесь n-step горизонтов (TF-style, TD-λ). Снижает дисперсию меток и согласуется с тем, как PPO/A2C обрабатывают возвраты.
+6. Нормализация/клип:
+  допускается только глобальный winsorize/клип/робаст-скейл по train (единый для всех действий), чтобы стабилизировать обучение и
   подобрать разумную температуру τ для softmax. Не применять построчные/волатильностные нормировки.
-8. Таргеты для SL → PPO:
+7. Таргеты для SL → PPO:
   строим Y = softmax(Q/τ) с масками валидности (advantage-нормировка нежелательна на этапе SL, т.к. теряет глобальный контекст; 
   он нужен для калибровки PPO). Value-head для PPO можно инициализировать как Vτ(s) = τ * log Σ_a exp(Q_a/τ) (мягкий максимум) 
   или max_a Q_a.
@@ -177,57 +171,74 @@ def calc_position_metrics(
 
 
 # ------------------------------------------------------------
-# Основная разметка Q с mode ∈ {'exit','horizon','tdlambda'}
+# Симуляция позиции через BacktestEnv
+# ------------------------------------------------------------
+
+
+def _simulate_positions_via_env(
+    df: pd.DataFrame,
+    side_long: bool,
+    fee: float,
+    slippage: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Прогоняет действия с максимальным Q через ``BacktestEnv``.
+
+    Возвращает кортеж массивов ``(pos, entry_price)`` длины ``len(df)``
+    со состоянием позиции *перед* выполнением каждого шага.
+    """
+    cfg = EnvConfig(
+        mode=1 if side_long else -1,
+        fee=fee,
+        spread=slippage,
+        leverage=1.0,
+        max_steps=len(df) - 1,
+        reward_scale=1.0,
+        use_log_reward=False,
+        time_penalty=0.0,
+        hold_penalty=0.0,
+    )
+    env = BacktestEnv(df[["Open", "High", "Low", "Close"]], price_col="Open", cfg=cfg)
+    env.reset()
+
+    positions = []
+    entries = []
+    q_mat = df[["Q_Open", "Q_Close", "Q_Hold", "Q_Wait"]].to_numpy(np.float64)
+    for row in q_mat[:-1]:
+        positions.append(env.position)
+        entries.append(env.entry_price if env.position != 0 else np.nan)
+        mask = env.action_mask().astype(bool)
+        logits = np.where(np.isfinite(row), row, -1e9)
+        priority = np.array([2e-12, 3e-12, 4e-12, 1e-12])
+        logits = np.where(mask, logits + priority, -1e9)
+        action = int(np.argmax(logits))
+        _, _, done, _ = env.step(action)
+        if done:
+            break
+
+    positions.append(env.position)
+    entries.append(env.entry_price if env.position != 0 else np.nan)
+    return np.array(positions, dtype=np.int8), np.array(entries, dtype=np.float64)
+
+
+# ------------------------------------------------------------
+# Основная разметка Q по TD-λ смеси n-step горизонтов
 # ------------------------------------------------------------
 
 
 def enrich_q_labels_trend_one_side(
     df: pd.DataFrame,
-    mode: Literal["exit", "horizon", "tdlambda"] = "exit",
     side_long: bool = True,
-    # для 'horizon'
-    horizon: int = 60,
-    # для 'tdlambda'
     H_max: int = 60,
     lam: float = 0.9,
-    # комиссии и проскальзывание (доли, например 0.0002 = 2 bps)
     fee: float = 0.0002,
     slippage: float = 0.0001,
-    # MAE-штраф (по желанию) — применяется ТОЛЬКО к Hold/Open (см. ниже)
-    use_mae_penalty: bool = False,
-    mae_lambda: float = 0.0,  # 0.0 = нет штрафа
-    mae_apply_to: Literal["hold", "open", "both", "none"] = "hold",
 ) -> pd.DataFrame:
+    """TD-λ разметка абсолютных Q для действий Open/Close/Hold/Wait.
+
+    Позиция и маски валидности определяются через симуляцию на
+    ``BacktestEnv`` с выбором действия максимального Q на каждом шаге.
     """
-    Размечает абсолютные Q для one-side (long-only или short-only) и действий: Open / Close / Hold / Wait.
-    Всегда предполагается исполнение решений на next open (t -> t+1).
-
-    mode='exit':
-        Open = Ret(t+1 -> exit_exec), c обеими ногами издержек
-        Close = 0
-        Hold = Ret(t+1 -> exit_exec)
-        Wait = 0
-
-    mode='horizon':
-        Open = Ret(t+1 -> t+H), с издержками входа и выхода
-        Close = 0
-        Hold = Ret(t+1 -> t+H)
-        Wait = 0
-
-    mode='tdlambda':
-        Open = Σ_{n=1..H_max} w_n * Ret(t+1 -> t+n), с издержками входа/выхода
-        Close = 0
-        Hold = Σ_{n=1..H_max} w_n * Ret(t+1 -> t+n)
-        Wait = 0
-        где w_n = (1-λ) λ^{n-1} / нормировка.
-
-    Все Q — АБСОЛЮТНЫЕ доходности (без деления на σ или √Δt).
-    Маски Mask_* показывают исполнимость действия в моменте.
-
-    Требуемые колонки df: 'Open','High','Low','Close','Signal_Rule'
-      Signal_Rule: +1 — buy-сигнал, -1 — sell-сигнал (для teacher)
-    """
-    need = {"Open", "High", "Low", "Close", "Signal_Rule"}
+    need = {"Open", "High", "Low", "Close"}
     miss = need - set(df.columns)
     if miss:
         raise ValueError(f"нет колонок: {sorted(miss)}")
@@ -239,26 +250,6 @@ def enrich_q_labels_trend_one_side(
     Close = out["Close"].to_numpy(np.float64)
     n = len(Open)
 
-    # сигналы учителя (ПРОВЕРЬ соответствие под твой пайплайн!)
-    buy_sig = out["Signal_Rule"].to_numpy() == 1
-    sell_sig = out["Signal_Rule"].to_numpy() == -1
-    buy_sig = buy_sig.astype(np.bool_)
-    sell_sig = sell_sig.astype(np.bool_)
-
-    # позиция учителя (для entry_eff/pos)
-    pos, entry_eff = simulate_position_one_side(
-        Open, buy_sig, sell_sig, side_long=side_long
-    )
-    out["Pos"] = pos 
-    # метрики текущей позиции
-    unreal, flat_steps, hold_steps, drawdown = calc_position_metrics(
-        pos, entry_eff, High, Low, Close, side_long=side_long
-    )
-    out["Unreal_PnL"] = unreal.astype(np.float32)
-    out["Flat_Steps"] = (flat_steps / 1000).astype(np.float32) 
-    out["Hold_Steps"] = (hold_steps / 1000).astype(np.float32) 
-    out["Drawdown"] = drawdown.astype(np.float32)
-
     # исполнение "сейчас" — next open
     exec_next_open = np.full(n, np.nan)
     exec_next_open[:-1] = Open[1:]
@@ -267,304 +258,100 @@ def enrich_q_labels_trend_one_side(
     c_open = fee + slippage
     c_close = fee + slippage
 
-    # маски состояний
-    pos_now = pos
-    flat = pos_now == 0
-    inpos = (pos_now != 0) & np.isfinite(entry_eff)
     has_next = np.arange(n) < n - 1
 
-    # контейнеры Q и масок
+    # контейнеры Q
     Q_Open = np.full(n, np.nan, np.float64)
     Q_Close = np.full(n, np.nan, np.float64)
     Q_Hold = np.full(n, np.nan, np.float64)
-    Q_Wait = np.full(n, np.nan, np.float64)
+    Q_Wait = np.zeros(n, np.float64)
 
-    M_Open = np.zeros(n, np.int8)
-    M_Close = np.zeros(n, np.int8)
-    M_Hold = np.zeros(n, np.int8)
-    M_Wait = np.zeros(n, np.int8)
+    # TD(λ): смесь n-step горизонтов (TF-style)
+    Hm = int(max(1, H_max))
+    fut = np.full((n, Hm), np.nan, dtype=np.float64)
+    for j in range(1, Hm + 1):
+        idx = np.arange(n) + j
+        ok = idx < n
+        fut[ok, j - 1] = Open[idx[ok]]
 
-    # ------------------------------
-    # mode = 'exit' : продолжение до teacher-exit
-    # ------------------------------
-    if mode == "exit":
-        # ближайший future exit (exec@next open)
-        exit_idx, exit_px = next_exit_exec_arrays(
-            Open, buy_sig, sell_sig, side_long=side_long
-        )
-        has_exit = exit_idx >= (
-            np.arange(n) + 2
-        )  # нужен хотя бы один бар PnL: t+1 -> exit
+    w = np.array(
+        [(1.0 - lam) * (lam ** (k - 1)) for k in range(1, Hm + 1)], dtype=np.float64
+    )
+    w = w / np.sum(w)
 
-        # Open (flat): t+1 -> exit, с обеими ногами издержек
-        m_open = flat & has_next & has_exit
+    # Open: смесь n-step, если есть будущее
+    m_open = has_next
+    if np.any(m_open):
         if side_long:
-            entry_eff_open = exec_next_open * (1.0 + c_open)
-            exit_eff_open = exit_px * (1.0 - c_close)
-            Q_Open[m_open] = exit_eff_open[m_open] / entry_eff_open[m_open] - 1.0
+            entry_eff = (exec_next_open[m_open] * (1.0 + c_open))[:, None]
+            exit_eff = fut[m_open, :] * (1.0 - c_close)
+            vals = exit_eff / entry_eff - 1.0
         else:
-            entry_eff_open = exec_next_open * (1.0 - c_open)  # sell
-            exit_eff_open = exit_px * (1.0 + c_close)  # buy
-            Q_Open[m_open] = entry_eff_open[m_open] / exit_eff_open[m_open] - 1.0
-        M_Open[m_open] = 1
+            entry_eff = (exec_next_open[m_open] * (1.0 - c_open))[:, None]
+            exit_eff = fut[m_open, :] * (1.0 + c_close)
+            vals = entry_eff / exit_eff - 1.0
+        mask_cols = np.isfinite(vals)
+        vals[~mask_cols] = np.nan
+        weights = np.broadcast_to(w, vals.shape).copy()
+        weights[~mask_cols] = 0.0
+        denom = weights.sum(axis=1, keepdims=True)
+        valid_rows = denom.squeeze(1) > 0.0
+        denom[denom == 0.0] = np.nan
+        q_vals = np.nansum(vals * weights, axis=1) / denom.squeeze(1)
+        idx_rows = np.where(m_open)[0]
+        Q_Open[idx_rows[valid_rows]] = q_vals[valid_rows]
 
-        # Close (inpos): в TD-конвенции — baseline "дальше 0"
-        m_close = inpos & has_next
-        Q_Close[m_close] = 0.0
-        M_Close[m_close] = 1
+    # Close: 0, если есть следующий бар
+    Q_Close[has_next] = 0.0
 
-        # Hold (inpos): t+1 -> exit (continuation)
-        m_hold = inpos & has_next & has_exit
+    # Hold: смесь n-step, если есть будущее
+    m_hold = has_next
+    if np.any(m_hold):
         if side_long:
-            Q_Hold[m_hold] = (exit_px[m_hold] / exec_next_open[m_hold]) - 1.0
+            vals = (fut[m_hold, :] / exec_next_open[m_hold, None]) - 1.0
         else:
-            Q_Hold[m_hold] = (exec_next_open[m_hold] / exit_px[m_hold]) - 1.0
-        M_Hold[m_hold] = 1
+            vals = (exec_next_open[m_hold, None] / fut[m_hold, :]) - 1.0
+        mask_cols = np.isfinite(vals)
+        vals[~mask_cols] = np.nan
+        weights = np.broadcast_to(w, vals.shape).copy()
+        weights[~mask_cols] = 0.0
+        denom = weights.sum(axis=1, keepdims=True)
+        valid_rows = denom.squeeze(1) > 0.0
+        denom[denom == 0.0] = np.nan
+        q_vals = np.nansum(vals * weights, axis=1) / denom.squeeze(1)
+        idx_rows = np.where(m_hold)[0]
+        Q_Hold[idx_rows[valid_rows]] = q_vals[valid_rows]
 
-        # Wait (flat): 0
-        m_wait = flat
-        Q_Wait[m_wait] = 0.0
-        M_Wait[m_wait] = 1
-
-        # опционально: MAE-штраф (уменьшает Q_Hold и/или Q_Open)
-        if use_mae_penalty and mae_lambda > 0.0:
-            # штраф считаем по пути t+1...exit-1 относительно ExecNow
-            def mae_fwd_long(t):
-                L, R = t + 1, exit_idx[t]
-                if R <= L or not np.isfinite(exec_next_open[t]):
-                    return 0.0
-                worst = np.nanmin(Low[L:R])
-                return min(worst / exec_next_open[t] - 1.0, 0.0)
-
-            def mae_fwd_short(t):
-                L, R = t + 1, exit_idx[t]
-                if R <= L or not np.isfinite(exec_next_open[t]):
-                    return 0.0
-                worst = np.nanmax(High[L:R])
-                return min(exec_next_open[t] / worst - 1.0, 0.0)
-
-            # HOLD
-            if mae_apply_to in ("hold", "both"):
-                idxs = np.where(M_Hold == 1)[0]
-                if side_long:
-                    penalties = np.array([mae_fwd_long(t) for t in idxs])
-                else:
-                    penalties = np.array([mae_fwd_short(t) for t in idxs])
-                Q_Hold[idxs] = Q_Hold[idxs] - mae_lambda * np.abs(penalties)
-
-            # OPEN
-            if mae_apply_to in ("open", "both"):
-                idxs = np.where(M_Open == 1)[0]
-                if side_long:
-                    penalties = np.array([mae_fwd_long(t) for t in idxs])
-                else:
-                    penalties = np.array([mae_fwd_short(t) for t in idxs])
-                Q_Open[idxs] = Q_Open[idxs] - mae_lambda * np.abs(penalties)
-
-    # ------------------------------
-    # mode = 'horizon' : фиксированный горизонт H
-    # ------------------------------
-    elif mode == "horizon":
-        H = int(max(1, horizon))
-        fut_idx = np.arange(n) + H
-        has_fut = fut_idx < n
-
-        fut_px = np.full(n, np.nan)
-        fut_px[has_fut] = Open[fut_idx[has_fut]]
-
-        # Open (flat): t+1 -> t+H, с обеими ногами издержек
-        m_open = flat & has_next & has_fut
-        if side_long:
-            entry_eff_open = exec_next_open * (1.0 + c_open)
-            exit_eff_open = fut_px * (1.0 - c_close)
-            Q_Open[m_open] = exit_eff_open[m_open] / entry_eff_open[m_open] - 1.0
-        else:
-            entry_eff_open = exec_next_open * (1.0 - c_open)
-            exit_eff_open = fut_px * (1.0 + c_close)
-            Q_Open[m_open] = entry_eff_open[m_open] / exit_eff_open[m_open] - 1.0
-        M_Open[m_open] = 1
-
-        # Close: 0
-        m_close = inpos & has_next
-        Q_Close[m_close] = 0.0
-        M_Close[m_close] = 1
-
-        # Hold: t+1 -> t+H
-        m_hold = inpos & has_next & has_fut
-        if side_long:
-            Q_Hold[m_hold] = (fut_px[m_hold] / exec_next_open[m_hold]) - 1.0
-        else:
-            Q_Hold[m_hold] = (exec_next_open[m_hold] / fut_px[m_hold]) - 1.0
-        M_Hold[m_hold] = 1
-
-        # Wait: 0
-        m_wait = flat
-        Q_Wait[m_wait] = 0.0
-        M_Wait[m_wait] = 1
-
-        # (опционально) MAE-штраф к Hold/Open — в горизонте считаем MAE на [t+1, t+H)
-        if use_mae_penalty and mae_lambda > 0.0:
-
-            def mae_h_long(t):
-                L, R = t + 1, t + H
-                if R <= L or not np.isfinite(exec_next_open[t]) or R > n:
-                    return 0.0
-                worst = np.nanmin(Low[L:R])
-                return min(worst / exec_next_open[t] - 1.0, 0.0)
-
-            def mae_h_short(t):
-                L, R = t + 1, t + H
-                if R <= L or not np.isfinite(exec_next_open[t]) or R > n:
-                    return 0.0
-                worst = np.nanmax(High[L:R])
-                return min(exec_next_open[t] / worst - 1.0, 0.0)
-
-            if mae_apply_to in ("hold", "both"):
-                idxs = np.where(M_Hold == 1)[0]
-                penalties = np.array(
-                    [mae_h_long(t) if side_long else mae_h_short(t) for t in idxs]
-                )
-                Q_Hold[idxs] = Q_Hold[idxs] - mae_lambda * np.abs(penalties)
-
-            if mae_apply_to in ("open", "both"):
-                idxs = np.where(M_Open == 1)[0]
-                penalties = np.array(
-                    [mae_h_long(t) if side_long else mae_h_short(t) for t in idxs]
-                )
-                Q_Open[idxs] = Q_Open[idxs] - mae_lambda * np.abs(penalties)
-
-    # ------------------------------
-    # mode = 'tdlambda' : смесь n-step горизонтов (TF-style)
-    # ------------------------------
-    elif mode == "tdlambda":
-        Hm = int(max(1, H_max))
-        # подготовим будущие Open для n=1..Hm
-        fut = np.full((n, Hm), np.nan, dtype=np.float64)
-        for j in range(1, Hm + 1):
-            idx = np.arange(n) + j
-            ok = idx < n
-            fut[ok, j - 1] = Open[idx[ok]]
-
-        # веса TD(λ)
-        w = np.array(
-            [(1.0 - lam) * (lam ** (k - 1)) for k in range(1, Hm + 1)], dtype=np.float64
-        )
-        w = w / np.sum(w)
-
-        # Open (flat): смесь n-step
-        m_open = flat & has_next
-        if np.any(m_open):
-            if side_long:
-                entry_eff = (exec_next_open[m_open] * (1.0 + c_open))[:, None]
-                exit_eff = fut[m_open, :] * (1.0 - c_close)
-                vals = exit_eff / entry_eff - 1.0
-            else:
-                entry_eff = (exec_next_open[m_open] * (1.0 - c_open))[:, None]  # sell
-                exit_eff = fut[m_open, :] * (1.0 + c_close)  # buy
-                vals = entry_eff / exit_eff - 1.0
-            # валидные столбцы: где fut не NaN
-            mask_cols = np.isfinite(vals)
-            vals[~mask_cols] = np.nan
-            # средневзвешенно по доступным n (нормировка по доступным весам)
-            weights = np.broadcast_to(w, vals.shape).copy()
-            weights[~mask_cols] = 0.0
-            denom = weights.sum(axis=1, keepdims=True)
-            valid_rows = denom.squeeze(1) > 0.0
-            denom[denom == 0.0] = np.nan  # чтобы итог был NaN, а не 0
-            q_vals = np.nansum(vals * weights, axis=1) / denom.squeeze(1)
-            # назначаем только туда, где есть хотя бы один валидный горизонт
-            idx_rows = np.where(m_open)[0]
-            Q_Open[idx_rows[valid_rows]] = q_vals[valid_rows]
-            M_Open[idx_rows[valid_rows]] = 1
-
-        # Close: 0
-        m_close = inpos & has_next
-        Q_Close[m_close] = 0.0
-        M_Close[m_close] = 1
-
-        # Hold (inpos): смесь n-step
-        m_hold = inpos & has_next
-        if np.any(m_hold):
-            if side_long:
-                vals = (fut[m_hold, :] / exec_next_open[m_hold, None]) - 1.0
-            else:
-                vals = (exec_next_open[m_hold, None] / fut[m_hold, :]) - 1.0
-            mask_cols = np.isfinite(vals)
-            vals[~mask_cols] = np.nan
-            weights = np.broadcast_to(w, vals.shape).copy()
-            weights[~mask_cols] = 0.0
-            denom = weights.sum(axis=1, keepdims=True)
-            valid_rows = denom.squeeze(1) > 0.0
-            denom[denom == 0.0] = np.nan
-            q_vals = np.nansum(vals * weights, axis=1) / denom.squeeze(1)
-            idx_rows = np.where(m_hold)[0]
-            Q_Hold[idx_rows[valid_rows]] = q_vals[valid_rows]
-            M_Hold[idx_rows[valid_rows]] = 1
-
-        # Wait: 0
-        m_wait = flat
-        Q_Wait[m_wait] = 0.0
-        M_Wait[m_wait] = 1
-
-        # опциональный MAE-штраф (на интервалах [t+1, t+n)), применим эквивалентно к средневзвешенной MAE
-        if use_mae_penalty and mae_lambda > 0.0:
-            # Предвычислим MAE для каждого n (дороже, но прозрачно)
-            N = n  # длина временного ряда
-
-            def mae_n_long(t, n_step):
-                L, R = t + 1, t + n_step  # R - правая граница (исключительная)
-                if R <= L or R > N or not np.isfinite(exec_next_open[t]):
-                    return 0.0
-                worst = np.nanmin(Low[L:R])
-                return min(worst / exec_next_open[t] - 1.0, 0.0)
-
-            def mae_n_short(t, n_step):
-                L, R = t + 1, t + n_step
-                if R <= L or R > N or not np.isfinite(exec_next_open[t]):
-                    return 0.0
-                worst = np.nanmax(High[L:R])
-                return min(exec_next_open[t] / worst - 1.0, 0.0)
-
-            # HOLD
-            if mae_apply_to in ("hold", "both"):
-                idxs = np.where(M_Hold == 1)[0]
-                penalties = []
-                for t in idxs:
-                    acc = 0.0
-                    zw = 0.0
-                    for j in range(1, Hm + 1):
-                        R = t + j
-                        if R < N:
-                            pen = mae_n_long(t, j) if side_long else mae_n_short(t, j)
-                            acc += w[j - 1] * np.abs(pen)
-                            zw += w[j - 1]
-                    penalties.append(acc / (zw + 1e-12))
-                Q_Hold[idxs] = Q_Hold[idxs] - mae_lambda * np.asarray(penalties)
-
-            # OPEN
-            if mae_apply_to in ("open", "both"):
-                idxs = np.where(M_Open == 1)[0]
-                penalties = []
-                for t in idxs:
-                    acc = 0.0
-                    zw = 0.0
-                    for j in range(1, Hm + 1):
-                        R = t + j
-                        if R < N:
-                            pen = mae_n_long(t, j) if side_long else mae_n_short(t, j)
-                            acc += w[j - 1] * np.abs(pen)
-                            zw += w[j - 1]
-                    penalties.append(acc / (zw + 1e-12))
-                Q_Open[idxs] = Q_Open[idxs] - mae_lambda * np.asarray(penalties)
-
-    else:
-        raise ValueError("mode ∈ {'exit','horizon','tdlambda'}")
-
-    # итоговые колонки
+    # Итоговые Q-колонки (масштабируем для стабильности)
     out["Q_Open"] = Q_Open.astype(np.float32) / 2e-3
     out["Q_Close"] = Q_Close.astype(np.float32) / 2e-3
     out["Q_Hold"] = Q_Hold.astype(np.float32) / 2e-3
     out["Q_Wait"] = Q_Wait.astype(np.float32) / 2e-3
+
+    # Симуляция позиции по максимальному Q
+    pos, entry_eff = _simulate_positions_via_env(out, side_long, fee, slippage)
+
+    # Метрики текущей позиции
+    unreal, flat_steps, hold_steps, drawdown = calc_position_metrics(
+        pos, entry_eff, High, Low, Close, side_long=side_long
+    )
+    out["Pos"] = pos
+    out["Unreal_PnL"] = unreal.astype(np.float32)
+    out["Flat_Steps"] = (flat_steps / 1000).astype(np.float32)
+    out["Hold_Steps"] = (hold_steps / 1000).astype(np.float32)
+    out["Drawdown"] = drawdown.astype(np.float32)
+
+    # Маски валидности на основе симулированной позиции
+    flat = pos == 0
+    inpos = pos != 0
+    valid_open = np.isfinite(Q_Open)
+    valid_hold = np.isfinite(Q_Hold)
+    valid_close = np.isfinite(Q_Close)
+
+    M_Open = (flat & has_next & valid_open).astype(np.int8)
+    M_Close = (inpos & has_next & valid_close).astype(np.int8)
+    M_Hold = (inpos & has_next & valid_hold).astype(np.int8)
+    M_Wait = flat.astype(np.int8)
 
     out["Mask_Open"] = M_Open
     out["Mask_Close"] = M_Close


### PR DESCRIPTION
## Summary
- simplify `enrich_q_labels_trend_one_side` to always use TD-λ mixture
- drop MAE penalty and legacy exit/horizon modes
- derive position trajectory and action masks by simulating greedy policy with `BacktestEnv`

## Testing
- `pytest tests/test_q_labels.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b844fdee70832eabe32637e5fea327