### PR TITLE
feat: incorporate commissions into Q-labels

### DIFF
--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -197,7 +197,7 @@ def test_class_balance_weights_excludes_unused_rows():
         sw_mode="ClassBalance",
     )
     splits = builder.fit_transform(df)
-    SWtr = splits["train"][6]
+    SWtr = splits["train"][5]
 
     expected_invfreq = np.array([2.5, 5.0, 5.0, 5.0], dtype=np.float32)
     expected_sw = np.array([1.25, 1.25, 0.625, 1.25, 0.625], dtype=np.float32)

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -33,7 +33,7 @@ def _make_df(n: int = 40) -> pd.DataFrame:
             "drawdown": np.zeros(n),
         }
     )
-    df = enrich_q_labels_trend_one_side(df, mode="horizon", horizon=3)
+    df = enrich_q_labels_trend_one_side(df, H_max=3)
     return df
 
 


### PR DESCRIPTION
## Summary
- subtract entry and exit commissions when computing Q_Open, Q_Hold and Q_Close
- add regression test for commission-only scenario and align dataset builder test
- adjust integration pipeline to new `enrich_q_labels_trend_one_side` API
- add configurable scaling for Q labels: constant or causal volatility
- verify volatility-based scaling in unit tests

## Testing
- `pytest tests/test_q_labels.py -q`
- `pytest tests/test_visualisation.py -q`
- `pytest tests/test_integration_pipeline.py::test_full_pipeline -q`
- `pytest tests/test_dataset_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b850835764832eb82ecfb59c8e78a1