### PR TITLE
feat: load actor weights in builder

### DIFF
--- a/scr/ppo_training.py
+++ b/scr/ppo_training.py
@@ -23,12 +23,24 @@ NUM_ACTIONS = 4
 
 
 def build_actor_critic(
-    seq_len: int, feature_dim: int, num_actions: int = NUM_ACTIONS
+    seq_len: int,
+    feature_dim: int,
+    num_actions: int = NUM_ACTIONS,
+    actor_weights: Optional[str] = None,
 ) -> Tuple[keras.Model, keras.Model]:
-    """Создать сети актёра и критика с общей архитектурой."""
+    """Создать сети актёра и критика с общей архитектурой.
+
+    Если передан ``actor_weights``, веса актёра загружаются после явной
+    инициализации сети.
+    """
 
     actor = build_stacked_residual_lstm(seq_len, feature_dim, num_classes=num_actions)
     critic = build_stacked_residual_lstm(seq_len, feature_dim, num_classes=1)
+
+    if actor_weights:
+        actor.build((None, seq_len, feature_dim))
+        actor.load_weights(actor_weights)
+
     return actor, critic
 
 

--- a/tests/test_ppo_training.py
+++ b/tests/test_ppo_training.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import tensorflow as tf
 from tensorflow import keras
 
 from scr.backtest_env import BacktestEnv, EnvConfig
@@ -34,6 +35,18 @@ def test_build_and_collect():
     assert traj.actions.shape == (1,)
     assert traj.returns.shape == (1,)
     assert traj.advantages.shape == (1,)
+
+
+def test_build_actor_critic_loads_weights(tmp_path):
+    model = build_stacked_residual_lstm(1, 1, num_classes=4)
+    for w in model.trainable_weights:
+        w.assign(tf.ones_like(w))
+    weight_path = tmp_path / "actor.weights.h5"
+    model.save_weights(weight_path)
+
+    actor, _ = build_actor_critic(seq_len=1, feature_dim=1, actor_weights=str(weight_path))
+    for w in actor.trainable_weights:
+        assert np.allclose(w.numpy(), np.ones_like(w.numpy()))
 
 
 def test_ppo_update_kl_decay():


### PR DESCRIPTION
## Summary
- allow `build_actor_critic` to optionally load pretrained actor weights
- cover new weight-loading path with tests

## Testing
- `flake8 scr/ppo_training.py tests/test_ppo_training.py`
- `PYTHONPATH=. pytest tests/test_ppo_training.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb5a67cd00832ebeb6a2b7a02e5de3