### PR TITLE
Refactor PPO data pipeline

### DIFF
--- a/tests/test_ppo_training.py
+++ b/tests/test_ppo_training.py
@@ -1,20 +1,28 @@
+import os
+import sys
 import numpy as np
 import pandas as pd
 import tensorflow as tf
 from tensorflow import keras
 
-from scr.backtest_env import BacktestEnv, EnvConfig
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scr.backtest_env import EnvConfig
 from scr.ppo_training import (
     build_actor_critic,
     collect_trajectories,
     ppo_update,
+    prepare_datasets,
 )
 from scr.residual_lstm import build_stacked_residual_lstm, VERY_NEG
 
 
-def make_env():
-    df = pd.DataFrame({"close": [1.0, 1.0], "feat": [0.0, 0.0]})
-    cfg = EnvConfig(
+def make_df():
+    return pd.DataFrame({"close": np.ones(20), "feat": np.zeros(20)})
+
+
+def make_cfg():
+    return EnvConfig(
         mode=1,
         fee=0.0,
         spread=0.0,
@@ -25,31 +33,50 @@ def make_env():
         time_penalty=0.0,
         hold_penalty=0.0,
     )
-    return BacktestEnv(df, feature_cols=["feat"], cfg=cfg)
 
 
 def test_build_and_collect():
-    env = make_env()
-    env.reset()
-    feature_dim = env.features.shape[1] + env._get_state().shape[0]
-    actor, critic = build_actor_critic(seq_len=1, feature_dim=feature_dim)
+    df = make_df()
+    train_df, _, _, feat_cols, state_stats = prepare_datasets(df)
+    cfg = make_cfg()
+    seq_len = 1
+    feature_dim = len(feat_cols) + 5
+    actor, critic = build_actor_critic(seq_len, feature_dim)
     traj = collect_trajectories(
-        env, actor, critic, batch_size=1, seq_len=1, feature_dim=feature_dim
+        train_df,
+        actor,
+        critic,
+        cfg,
+        feat_cols,
+        state_stats,
+        n_env=2,
+        rollout=2,
+        seq_len=seq_len,
     )
-    assert traj.obs.shape == (1, 1, feature_dim)
-    assert traj.actions.shape == (1,)
-    assert traj.returns.shape == (1,)
-    assert traj.advantages.shape == (1,)
+    assert traj.obs.shape == (4, seq_len, feature_dim)
+    assert traj.actions.shape == (4,)
+    assert traj.returns.shape == (4,)
+    assert traj.advantages.shape == (4,)
 
 
 def test_ppo_update_kl_decay():
-    env = make_env()
-    env.reset()
-    feature_dim = env.features.shape[1] + env._get_state().shape[0]
-    actor, critic = build_actor_critic(seq_len=1, feature_dim=feature_dim)
-    teacher = build_stacked_residual_lstm(1, feature_dim, num_classes=4)
+    df = make_df()
+    train_df, _, _, feat_cols, state_stats = prepare_datasets(df)
+    cfg = make_cfg()
+    seq_len = 1
+    feature_dim = len(feat_cols) + 5
+    actor, critic = build_actor_critic(seq_len, feature_dim)
+    teacher = build_stacked_residual_lstm(seq_len, feature_dim, num_classes=4)
     traj = collect_trajectories(
-        env, actor, critic, batch_size=1, seq_len=1, feature_dim=feature_dim
+        train_df,
+        actor,
+        critic,
+        cfg,
+        feat_cols,
+        state_stats,
+        n_env=1,
+        rollout=2,
+        seq_len=seq_len,
     )
     opt_a = keras.optimizers.Adam(1e-3)
     opt_c = keras.optimizers.Adam(1e-3)
@@ -72,30 +99,29 @@ def test_ppo_update_kl_decay():
 def test_collect_trajectories_nan_probs():
     class DummyActor(tf.keras.Model):
         def call(self, inputs, training=False):
-            return tf.constant([[np.nan, VERY_NEG, np.nan, VERY_NEG]], dtype=tf.float32)
+            batch = tf.shape(inputs)[0]
+            return tf.tile(
+                tf.constant([[np.nan, VERY_NEG, np.nan, VERY_NEG]], dtype=tf.float32),
+                [batch, 1],
+            )
 
-    class DummyEnv:
-        def __init__(self):
-            self.features = np.zeros((2, 1), dtype=np.float32)
-            self.t = 1
-            self.state = np.zeros(1, dtype=np.float32)
-            self.done = False
-
-        def reset(self):
-            self.t = 1
-            self.done = False
-            return {"state": self.state.copy()}
-
-        def step(self, action):
-            self.done = True
-            return {"state": self.state.copy()}, 0.0, True, {}
-
-        def action_mask(self):
-            return np.array([1, 0, 1, 0], dtype=np.float32)
-
-    env = DummyEnv()
-    critic = tf.keras.Sequential([tf.keras.layers.Dense(1)])
+    df = make_df()
+    train_df, _, _, feat_cols, state_stats = prepare_datasets(df)
+    cfg = make_cfg()
+    seq_len = 1
+    feature_dim = len(feat_cols) + 5
+    critic = keras.Sequential(
+        [keras.layers.Input(shape=(seq_len, feature_dim)), keras.layers.Flatten(), keras.layers.Dense(1)]
+    )
     traj = collect_trajectories(
-        env, DummyActor(), critic, batch_size=1, seq_len=2, feature_dim=2
+        train_df,
+        DummyActor(),
+        critic,
+        cfg,
+        feat_cols,
+        state_stats,
+        n_env=1,
+        rollout=1,
+        seq_len=seq_len,
     )
     assert np.all(np.isfinite(traj.old_logp))


### PR DESCRIPTION
## Summary
- add `prepare_datasets` to split DataFrame chronologically and compute normalization stats
- overhaul `collect_trajectories` for parallel window sampling over training data
- revise PPO `train` loop to use new dataset prep and rollout collection
- update tests for new API

## Testing
- `pytest tests/test_ppo_training.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbf807c2d4832e9181df25354aac70