### PR TITLE
refactor LSTM into backbone/head and load backbone for PPO

### DIFF
--- a/scr/optuna_tuner.py
+++ b/scr/optuna_tuner.py
@@ -6,7 +6,7 @@ import optuna
 import tensorflow as tf
 from optuna import Trial
 
-from .residual_lstm import build_stacked_residual_lstm
+from .residual_lstm import build_backbone, build_head, NUM_CLASSES
 from .train_eval import fit_model
 
 
@@ -51,23 +51,37 @@ def optimize_hyperparameters(
         dropout = trial.suggest_float("dropout", 0.1, 0.5)
         lr = trial.suggest_float("lr", 1e-5, 1e-2, log=True)
 
-        model = build_stacked_residual_lstm(
+        backbone = build_backbone(
             seq_len=seq_len,
-            feature_dim=feature_dim,
-            account_dim=acc_dim,
+            feature_dim=feature_dim + acc_dim,
             units_per_layer=units,
             dropout=dropout,
         )
+        model = build_head(backbone, NUM_CLASSES)
+
+        def _merge(ds: tf.data.Dataset) -> tf.data.Dataset:
+            def _map(inputs, target):
+                feats, acc = inputs
+                acc_rep = tf.repeat(acc[:, None, :], repeats=seq_len, axis=1)
+                feats = tf.concat([feats, acc_rep], axis=-1)
+                return feats, target
+
+            return ds.map(_map)
+
+        train_merged = _merge(train_ds)
+        val_merged = _merge(val_ds)
 
         history = fit_model(
             model,
-            train_ds,
-            val_ds,
+            train_merged,
+            val_merged,
             epochs=epochs,
             lr=lr,
             early_stopping_patience=1,
             lr_mode=None,
             best_path="best_lstm.weights.h5",
+            backbone=backbone,
+            backbone_path="best_backbone.weights.h5",
         )
 
         return float(history["val"]["loss"][-1])

--- a/scr/train_eval.py
+++ b/scr/train_eval.py
@@ -386,6 +386,8 @@ def fit_model(
     lr_restart_patience: int = 3,
     lr_restart_shrink: float = 0.5,
     best_path: str = "best_lstm_weights.h5",
+    backbone: keras.Model | None = None,
+    backbone_path: str | None = None,
 ):
     """Обучить ``model`` и вернуть историю в виде словаря."""
 
@@ -485,6 +487,8 @@ def fit_model(
             no_improve = 0
             since_restart = 0
             model.save_weights(best_path)
+            if backbone is not None and backbone_path is not None:
+                backbone.save_weights(backbone_path)
         else:
             no_improve += 1
             since_restart += 1
@@ -504,6 +508,8 @@ def fit_model(
 
     try:
         model.load_weights(best_path)
+        if backbone is not None and backbone_path is not None:
+            backbone.load_weights(backbone_path)
         print(f"Restored best weights from {best_path}")
     except Exception as e:  # pragma: no cover - best effort
         print(f"Warning: could not restore best weights: {e}")

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -10,7 +10,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from scr.q_labels_matching import enrich_q_labels_trend_one_side
 from scr.dataset_builder import DatasetBuilderForYourColumns, NUM_CLASSES
-from scr.residual_lstm import build_stacked_residual_lstm
+from scr.residual_lstm import build_backbone, build_head
 from scr.train_eval import _unpack_batch
 from scr.calibrate import calibrate_model
 from scr.backtest_env import run_backtest_with_logits
@@ -50,11 +50,12 @@ def test_full_pipeline(tmp_path):
     splits = builder.fit_transform(df, return_indices=True)
     ds_tr, ds_va, ds_te = builder.as_tf_datasets(splits)
 
-    model = build_stacked_residual_lstm(
+    backbone = build_backbone(
         seq_len=5,
         feature_dim=len(builder.feature_names) + len(builder.account_names),
         units_per_layer=(8, 8),
     )
+    model = build_head(backbone, NUM_CLASSES)
 
     batch = next(iter(ds_tr.take(1)))
     xb, mb, yb, *_ = _unpack_batch(batch)

--- a/tests/test_ppo_training.py
+++ b/tests/test_ppo_training.py
@@ -14,7 +14,7 @@ from scr.ppo_training import (
     ppo_update,
     prepare_datasets,
 )
-from scr.residual_lstm import build_stacked_residual_lstm, VERY_NEG
+from scr.residual_lstm import build_backbone, build_head, VERY_NEG
 
 
 def make_df():
@@ -66,7 +66,8 @@ def test_ppo_update_kl_decay():
     seq_len = 1
     feature_dim = len(feat_cols) + 5
     actor, critic = build_actor_critic(seq_len, feature_dim)
-    teacher = build_stacked_residual_lstm(seq_len, feature_dim, num_classes=4)
+    teacher_backbone = build_backbone(seq_len, feature_dim)
+    teacher = build_head(teacher_backbone, 4)
     traj = collect_trajectories(
         train_df,
         actor,

--- a/tests/test_residual_lstm.py
+++ b/tests/test_residual_lstm.py
@@ -7,7 +7,8 @@ import pytest
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from scr.residual_lstm import (
-    build_stacked_residual_lstm,
+    build_backbone,
+    build_head,
     masked_logits_and_probs,
     masked_categorical_crossentropy,
     masked_accuracy,
@@ -17,9 +18,8 @@ from scr.residual_lstm import (
 
 
 def test_model_output_shape_and_inputs():
-    model = build_stacked_residual_lstm(
-        seq_len=5, feature_dim=5, units_per_layer=(4, 4)
-    )
+    backbone = build_backbone(seq_len=5, feature_dim=5, units_per_layer=(4, 4))
+    model = build_head(backbone, num_classes=4)
     assert len(model.inputs) == 1
     x = tf.random.normal((2, 5, 5))
     logits = model(x)


### PR DESCRIPTION
## Summary
- split residual LSTM into reusable backbone and head helpers
- allow `fit_model` to save/load backbone weights alongside model
- PPO training builds actor/critic from backbone and loads shared backbone weights; Optuna tuner updated accordingly

## Testing
- `pytest tests/test_residual_lstm.py tests/test_ppo_training.py tests/test_integration_pipeline.py tests/test_optuna_tuner.py tests/test_train_eval.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc35ddb8f4832e858652050bb3af25