### PR TITLE
Simplify backbone weight saving

### DIFF
--- a/scr/optuna_tuner.py
+++ b/scr/optuna_tuner.py
@@ -80,7 +80,6 @@ def optimize_hyperparameters(
             early_stopping_patience=1,
             lr_mode=None,
             best_path="best_lstm.weights.h5",
-            backbone=backbone,
             backbone_path="best_backbone.weights.h5",
         )
 

--- a/scr/train_eval.py
+++ b/scr/train_eval.py
@@ -386,10 +386,14 @@ def fit_model(
     lr_restart_patience: int = 3,
     lr_restart_shrink: float = 0.5,
     best_path: str = "best_lstm_weights.h5",
-    backbone: keras.Model | None = None,
     backbone_path: str | None = None,
 ):
-    """Обучить ``model`` и вернуть историю в виде словаря."""
+    """Обучить ``model`` и вернуть историю в виде словаря.
+
+    При указании ``backbone_path`` из ``model`` автоматически
+    извлекается бэкбон до слоя ``feat_last`` и его веса
+    сохраняются и восстанавливаются по указанному пути.
+    """
 
     try:
         import tensorflow_addons as tfa
@@ -407,6 +411,20 @@ def fit_model(
         )
     else:
         optimizer = keras.optimizers.Adam(learning_rate=lr, clipnorm=grad_clip_norm)
+
+    if backbone_path is not None:
+        try:
+            backbone = keras.Model(
+                model.input,
+                model.get_layer("feat_last").output,
+                name="ResidualLSTMBackbone",
+            )
+        except Exception as e:  # pragma: no cover - best effort
+            raise ValueError(
+                "backbone_path provided but model lacks layer 'feat_last' to infer backbone"
+            ) from e
+    else:
+        backbone = None
 
     def make_schedule(factor: float = 1.0):
         base = lr * factor
@@ -487,7 +505,7 @@ def fit_model(
             no_improve = 0
             since_restart = 0
             model.save_weights(best_path)
-            if backbone is not None and backbone_path is not None:
+            if backbone_path is not None:
                 backbone.save_weights(backbone_path)
         else:
             no_improve += 1
@@ -508,7 +526,7 @@ def fit_model(
 
     try:
         model.load_weights(best_path)
-        if backbone is not None and backbone_path is not None:
+        if backbone_path is not None:
             backbone.load_weights(backbone_path)
         print(f"Restored best weights from {best_path}")
     except Exception as e:  # pragma: no cover - best effort


### PR DESCRIPTION
## Summary
- Auto-infer ResidualLSTM backbone from model in `fit_model`
- Save/load backbone weights whenever a path is provided, no explicit model arg
- Document automatic backbone extraction

## Testing
- `pytest tests/test_optuna_tuner.py -q`
- `pytest tests/test_train_eval.py::test_unpack_batch_with_sw -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5fddd0f4832eaa0b5f0b823c669e