### PR TITLE
Refactor PPO training API to drop state stats

### DIFF
--- a/test_run.py
+++ b/test_run.py
@@ -69,9 +69,11 @@ def main() -> None:
 
     cfg = DEFAULT_CONFIG._replace(max_steps=10)
     df_ppo = df.drop(columns=["Pos", "un_pnl", "flat_steps", "hold_steps", "drawdown"])
+    feature_dim = len(builder.feature_names) + 5
     ppo_train(
         df_ppo,
         cfg,
+        feature_dim=feature_dim,
         seq_len=5,
         teacher_weights="sl_weights/best_lstm.weights.h5",
         backbone_weights="sl_weights/best_backbone.weights.h5",

--- a/tests/test_ppo_training.py
+++ b/tests/test_ppo_training.py
@@ -37,7 +37,7 @@ def make_cfg():
 
 def test_build_and_collect():
     df = make_df()
-    train_df, _, _, feat_cols, _, state_stats = prepare_datasets(df)
+    train_df, _, _, feat_cols, _ = prepare_datasets(df)
     cfg = make_cfg()
     seq_len = 1
     feature_dim = len(feat_cols) + 5
@@ -50,7 +50,6 @@ def test_build_and_collect():
         critic,
         cfg,
         feat_cols,
-        state_stats,
         n_env=2,
         rollout=2,
         seq_len=seq_len,
@@ -64,7 +63,7 @@ def test_build_and_collect():
 
 def test_ppo_update_kl_decay():
     df = make_df()
-    train_df, _, _, feat_cols, _, state_stats = prepare_datasets(df)
+    train_df, _, _, feat_cols, _ = prepare_datasets(df)
     cfg = make_cfg()
     seq_len = 1
     feature_dim = len(feat_cols) + 5
@@ -79,7 +78,6 @@ def test_ppo_update_kl_decay():
         critic,
         cfg,
         feat_cols,
-        state_stats,
         n_env=1,
         rollout=2,
         seq_len=seq_len,
@@ -117,7 +115,7 @@ def test_collect_trajectories_nan_probs():
             )
 
     df = make_df()
-    train_df, _, _, feat_cols, _, state_stats = prepare_datasets(df)
+    train_df, _, _, feat_cols, _ = prepare_datasets(df)
     cfg = make_cfg()
     seq_len = 1
     feature_dim = len(feat_cols) + 5
@@ -134,7 +132,6 @@ def test_collect_trajectories_nan_probs():
         critic,
         cfg,
         feat_cols,
-        state_stats,
         n_env=1,
         rollout=1,
         seq_len=seq_len,


### PR DESCRIPTION
## Summary
- simplify `prepare_datasets` and `collect_trajectories` by removing `state_stats`
- require `feature_dim` as explicit arg for PPO `train`
- update scripts and tests for the new API

## Testing
- `pytest tests/test_ppo_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd88cd0688832eb26da8cd6356d0a8