### PR TITLE
Refactor PPO trajectory collection and simplify residual LSTM

### DIFF
--- a/test_run.py
+++ b/test_run.py
@@ -37,7 +37,7 @@ def main() -> None:
     backbone = build_backbone(
         seq_len=5,
         feature_dim=len(builder.feature_names) + len(builder.account_names),
-        units_per_layer=(8, 8),
+        units=8,
     )
     model = build_head(backbone, NUM_CLASSES)
     fit_model(
@@ -79,7 +79,7 @@ def main() -> None:
         backbone_weights="sl_weights/best_backbone.weights.h5",
         save_path="ppo_weights",
         num_actions=4,
-        units_per_layer=[8, 8],
+        units=8,
         dropout=0.2,
         updates=1,
         n_env=1,

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -53,7 +53,7 @@ def test_full_pipeline(tmp_path):
     backbone = build_backbone(
         seq_len=5,
         feature_dim=len(builder.feature_names) + len(builder.account_names),
-        units_per_layer=(8, 8),
+        units=8,
     )
     model = build_head(backbone, NUM_CLASSES)
 

--- a/tests/test_optuna_tuner.py
+++ b/tests/test_optuna_tuner.py
@@ -24,5 +24,5 @@ def test_optuna_tune_runs():
     params = optimize_hyperparameters(
         train_ds, val_ds, seq_len=5, feature_dim=3, acc_dim=2, n_trials=1, epochs=1
     )
-    assert set(params) == {"units_per_layer", "dropout", "lr"}
-    assert len(params["units_per_layer"]) == 3
+    assert set(params) == {"units", "dropout", "lr"}
+    assert isinstance(params["units"], int)

--- a/tests/test_ppo_training.py
+++ b/tests/test_ppo_training.py
@@ -215,9 +215,7 @@ def test_train_freeze_backbones(tmp_path):
     seq_len = 1
     feature_dim = len(feat_cols) + 5
     weight_path = tmp_path / "weights.weights.h5"
-    backbone = build_backbone(
-        seq_len, feature_dim, units_per_layer=[64, 32], dropout=0.5
-    )
+    backbone = build_backbone(seq_len, feature_dim, units=64, dropout=0.5)
     model = build_head(backbone, 4)
     model.save_weights(weight_path)
     actor, critic, _, _ = train(
@@ -233,7 +231,7 @@ def test_train_freeze_backbones(tmp_path):
         backbone_weights=str(weight_path),
         save_path=str(tmp_path),
         num_actions=4,
-        units_per_layer=[64, 32],
+        units=64,
         dropout=0.5,
         updates=1,
         n_env=1,

--- a/tests/test_residual_lstm.py
+++ b/tests/test_residual_lstm.py
@@ -18,7 +18,7 @@ from scr.residual_lstm import (
 
 
 def test_model_output_shape_and_inputs():
-    backbone = build_backbone(seq_len=5, feature_dim=5, units_per_layer=(4, 4))
+    backbone = build_backbone(seq_len=5, feature_dim=5, units=4)
     model = build_head(backbone, num_classes=4)
     assert len(model.inputs) == 1
     x = tf.random.normal((2, 5, 5))


### PR DESCRIPTION
## Summary
- replace the residual LSTM stack with a compact single-layer backbone that exposes a simple `units` integer parameter and update call sites/tests
- add a reusable state buffer and optional history logging to `BacktestEnv`, fix penalty handling, and extend metrics to report equity while guarding history access
- rework PPO trajectory collection around thread-based stepping, preallocated ring buffers, batched actor/critic inference, and revised next-value computation; adjust training/evaluation utilities and optuna tuner for the new interfaces

## Testing
- pytest tests/test_residual_lstm.py tests/test_backtest_env.py tests/test_ppo_training.py tests/test_optuna_tuner.py tests/test_integration_pipeline.py test_run.py

------
https://chatgpt.com/codex/tasks/task_e_68cadff14bf4832e96fed2724e20b9a0