### PR TITLE
Handle end-of-data bounds in backtest env

### DIFF
--- a/scr/backtest_env.py
+++ b/scr/backtest_env.py
@@ -103,8 +103,15 @@ def _step_single(
     if cfg.max_steps is not None and next_t >= cfg.max_steps:
         done = True
 
-    # Текущая и следующая цены
+    # Текущая цена
     this_price = prices[t]
+
+    # Безопасно получаем следующую цену: если данных не хватает, используем
+    # последнюю доступную и сигнализируем о завершении эпизода
+    last_valid_idx = prices.shape[0] - 1
+    if next_t >= prices.shape[0]:
+        next_t = last_valid_idx
+        done = True
     next_price = prices[next_t]
 
     prev_position = position  # позиция до совершения действия


### PR DESCRIPTION
## Summary
- clamp the next price lookup in `BacktestEnv._step_single` to the last available candle when the index exceeds the price array
- flag the episode as done when price data is exhausted to avoid IndexError while keeping downstream calculations consistent

## Testing
- pytest tests/test_ppo_training.py::test_train_freeze_backbones

------
https://chatgpt.com/codex/tasks/task_e_68cbaa68c9ac832eb0432c307542e490