### PR TITLE
Refresh teacher after promoting new PPO champion

### DIFF
--- a/scr/ppo_training.py
+++ b/scr/ppo_training.py
@@ -848,6 +848,10 @@ def train(
                 best_profit = avg_profit
                 actor.save_weights(best_actor_path)
                 critic.save_weights(best_critic_path)
+                if teacher is not None:
+                    teacher.set_weights(actor.get_weights())
+                    teacher.trainable = False
+                kl_coef = teacher_kl
                 pending_baseline = ("Champion", current_eval_cache)
 
 


### PR DESCRIPTION
## Summary
- update champion promotion logic to copy the promoted actor's weights into the teacher model
- reset the KL coefficient after refreshing the teacher and reaffirm its frozen state

## Testing
- pytest tests/test_ppo_training.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc5453cc4832ebcf86a412bf388d8