### PR TITLE
Ensure validation windows sampled without replacement

### DIFF
--- a/scr/ppo_training.py
+++ b/scr/ppo_training.py
@@ -720,13 +720,25 @@ def train(
 
     val_windows: List[pd.DataFrame] = []
     if val_candidates is not None:
-        for _ in range(n_validations):
-            idx = int(np.random.choice(len(val_candidates)))
-            val_windows.append(val_candidates[idx].copy())
+        available = len(val_candidates)
+        if available < n_validations:
+            raise ValueError(
+                "Requested more validation windows than available in index_ranges: "
+                f"{n_validations} > {available}"
+            )
+        selected = np.random.choice(available, size=n_validations, replace=False)
+        for idx in selected:
+            val_windows.append(val_candidates[int(idx)].copy())
     else:
-        for _ in range(n_validations):
-            s = int(np.random.choice(val_starts))
-            val = val_df.iloc[s : s + val_required]
+        available = len(val_starts)
+        if available < n_validations:
+            raise ValueError(
+                "Requested more validation windows than available in val_df: "
+                f"{n_validations} > {available}"
+            )
+        selected = np.random.choice(val_starts, size=n_validations, replace=False)
+        for s in selected:
+            val = val_df.iloc[int(s) : int(s) + val_required].copy()
             val_windows.append(val)
 
     baseline_name = "Teacher"


### PR DESCRIPTION
## Summary
- prevent validation window sampling from using duplicate candidates by checking availability and drawing without replacement
- copy each selected validation window regardless of source to avoid shared references
- extend PPO training tests with scenarios covering index range sampling and insufficient validation data

## Testing
- pytest tests/test_ppo_training.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc837e374832e8fd7ed889fc102d0