### PR TITLE
Add signal-aware backtest environment with gating logic

### DIFF
--- a/scr/__init__.py
+++ b/scr/__init__.py
@@ -1,1 +1,11 @@
 """Утилиты для инструментов обучения с подкреплением."""
+
+from .backtest_env import BacktestEnv, DEFAULT_CONFIG, EnvConfig
+from .backtest_env_with_signals import BacktestEnvWithSignals
+
+__all__ = [
+    "BacktestEnv",
+    "BacktestEnvWithSignals",
+    "DEFAULT_CONFIG",
+    "EnvConfig",
+]

--- a/scr/backtest_env_with_signals.py
+++ b/scr/backtest_env_with_signals.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .backtest_env import BacktestEnv, DEFAULT_CONFIG, EnvConfig
+
+
+class BacktestEnvWithSignals(BacktestEnv):
+    """Расширение ``BacktestEnv`` с управлением торговли по сигналам."""
+
+    def __init__(
+        self,
+        df,
+        feature_cols: Optional[Sequence[str]] = None,
+        price_col: str = "close",
+        cfg: EnvConfig = DEFAULT_CONFIG,
+        ppo_true: bool = False,
+        record_history: Optional[bool] = None,
+        signals: Optional[Sequence[int]] = None,
+    ):
+        super().__init__(
+            df,
+            feature_cols=feature_cols,
+            price_col=price_col,
+            cfg=cfg,
+            ppo_true=ppo_true,
+            record_history=record_history,
+            signals=signals,
+        )
+        if self.signals is None:
+            raise ValueError("signals array is required for BacktestEnvWithSignals")
+        if self.cfg.n < 0:
+            raise ValueError("cfg.n must be non-negative")
+        self._countdown_remaining = 0
+        self.can_trade = False
+
+    def reset(self):
+        obs = super().reset()
+        self._countdown_remaining = 0
+        self.can_trade = False
+        return obs
+
+    def _pre_step_signal(self) -> tuple[int, Optional[int]]:
+        current_signal = int(self.signals[self.t])
+        forced_action: Optional[int] = None
+
+        if current_signal == -1:
+            self.can_trade = False
+            self._countdown_remaining = 0
+            forced_action = 1 if self.position != 0 else 3
+        elif current_signal == 1 and not self.can_trade:
+            if self.cfg.n <= 0:
+                self.can_trade = True
+            elif self._countdown_remaining == 0:
+                self._countdown_remaining = int(self.cfg.n)
+        return current_signal, forced_action
+
+    def _finalize_countdown(self, current_signal: int) -> None:
+        if current_signal == -1:
+            return
+        if self.cfg.n > 0 and not self.can_trade and self._countdown_remaining > 0:
+            self._countdown_remaining -= 1
+            if self._countdown_remaining == 0:
+                self.can_trade = True
+
+    def step(self, action, q_threshold: float | None = None):
+        current_signal, forced_action = self._pre_step_signal()
+
+        if forced_action is not None:
+            effective_action = forced_action
+            forced = forced_action
+        elif self.can_trade:
+            effective_action = action
+            forced = None
+        else:
+            forced = 2 if self.position != 0 else 3
+            effective_action = forced
+
+        obs, reward, done, info = super().step(effective_action, q_threshold=q_threshold)
+
+        self._finalize_countdown(current_signal)
+
+        info = dict(info)
+        info.update(
+            signal=current_signal,
+            can_trade=self.can_trade,
+            countdown=self._countdown_remaining,
+            forced_action=forced,
+            effective_action=None if forced is None else effective_action,
+        )
+        return obs, reward, done, info
+

--- a/tests/test_backtest_env_with_signals.py
+++ b/tests/test_backtest_env_with_signals.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from scr.backtest_env import BacktestEnv, EnvConfig
+from scr.backtest_env_with_signals import BacktestEnvWithSignals
+
+
+def make_df(length: int) -> pd.DataFrame:
+    prices = np.linspace(1.0, 1.0 + 0.1 * (length - 1), length)
+    return pd.DataFrame({"close": prices})
+
+
+def make_cfg(**overrides) -> EnvConfig:
+    base = dict(
+        mode=1,
+        fee=0.0,
+        spread=0.0,
+        leverage=1.0,
+        max_steps=100,
+        reward_scale=1.0,
+        valid_time=0,
+        time_penalty=0.0,
+        hold_penalty=0.0,
+        terminal_reward=False,
+        terminal_reward_coef=0.0,
+        close_deal_if_done=False,
+        only_positive_tr_reward=False,
+        n=overrides.get("n", 0),
+    )
+    base.update(overrides)
+    return EnvConfig(**base)
+
+
+def test_signals_validation_length_mismatch():
+    df = make_df(4)
+    cfg = make_cfg()
+    with pytest.raises(ValueError):
+        BacktestEnv(df, cfg=cfg, signals=[0, 1, 0])
+
+
+def test_signals_validation_value_range():
+    df = make_df(4)
+    cfg = make_cfg()
+    with pytest.raises(ValueError):
+        BacktestEnv(df, cfg=cfg, signals=[0, 2, 0, 1])
+
+
+def test_countdown_enables_trading():
+    df = make_df(6)
+    cfg = make_cfg(n=2)
+    signals = [1, 0, 0, 0, 0, 0]
+    env = BacktestEnvWithSignals(df, cfg=cfg, signals=signals)
+    env.reset()
+
+    # Step 0: countdown starts, trading still disabled
+    _, _, _, info = env.step(0)
+    assert env.position == 0
+    assert info["forced_action"] == 3
+    assert info["can_trade"] is False
+    assert info["countdown"] == 1
+
+    # Step 1: countdown finishes, trading becomes available on next step
+    _, _, _, info = env.step(0)
+    assert info["forced_action"] == 3
+    assert info["can_trade"] is True
+    assert info["countdown"] == 0
+
+    # Step 2: trading allowed, open position
+    _, _, _, info = env.step(0)
+    assert env.position == 1
+    assert info["forced_action"] is None
+    assert info["can_trade"] is True
+
+
+def test_signal_minus_one_forces_closure():
+    df = make_df(6)
+    cfg = make_cfg(n=1)
+    signals = [1, 1, -1, 0, 0, 0]
+    env = BacktestEnvWithSignals(df, cfg=cfg, signals=signals)
+    env.reset()
+
+    # Step 0: countdown start
+    env.step(0)
+    # Step 1: countdown expires, position can be opened
+    _, _, _, info = env.step(0)
+    assert env.can_trade is True
+    assert env.position == 1
+    assert info["forced_action"] is None
+
+    # Step 2 (signal -1): force close
+    _, _, _, info = env.step(2)
+    assert env.position == 0
+    assert info["forced_action"] == 1
+    assert info["can_trade"] is False
+    assert info["countdown"] == 0
+


### PR DESCRIPTION
## Summary
- extend EnvConfig with an `n` countdown parameter and allow BacktestEnv to validate optional signal arrays
- add BacktestEnvWithSignals implementing the signal-driven trade permission state machine and export it via the package initializer
- cover the new behaviour with unit tests for signal validation, countdown gating, and forced closures

## Testing
- pytest tests/test_backtest_env.py tests/test_backtest_env_with_signals.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c1c69c70832e8bf8844cba108883