### PR TITLE
Restrict signals to binary values in backtest environment

### DIFF
--- a/scr/backtest_env.py
+++ b/scr/backtest_env.py
@@ -332,8 +332,8 @@ class BacktestEnv:
                 raise ValueError("signals must be a 1D array")
             if sig_arr.shape[0] != len(self.df):
                 raise ValueError("signals length must match dataframe length")
-            if not np.all(np.isin(sig_arr, (-1, 0, 1))):
-                raise ValueError("signals must contain only -1, 0 or 1 values")
+            if not np.all(np.isin(sig_arr, (-1, 1))):
+                raise ValueError("signals must contain only -1 or 1 values")
             self.signals = sig_arr.astype(np.int8, copy=False)
         # Инициализация состояния
         self.reset()

--- a/tests/test_backtest_env_with_signals.py
+++ b/tests/test_backtest_env_with_signals.py
@@ -36,20 +36,27 @@ def test_signals_validation_length_mismatch():
     df = make_df(4)
     cfg = make_cfg()
     with pytest.raises(ValueError):
-        BacktestEnv(df, cfg=cfg, signals=[0, 1, 0])
+        BacktestEnv(df, cfg=cfg, signals=[1, -1, 1])
 
 
 def test_signals_validation_value_range():
     df = make_df(4)
     cfg = make_cfg()
     with pytest.raises(ValueError):
-        BacktestEnv(df, cfg=cfg, signals=[0, 2, 0, 1])
+        BacktestEnv(df, cfg=cfg, signals=[1, 2, -1, 1])
+
+
+def test_signals_validation_rejects_zero():
+    df = make_df(3)
+    cfg = make_cfg()
+    with pytest.raises(ValueError):
+        BacktestEnv(df, cfg=cfg, signals=[1, 0, -1])
 
 
 def test_countdown_enables_trading():
     df = make_df(6)
     cfg = make_cfg(n=2)
-    signals = [1, 0, 0, 0, 0, 0]
+    signals = [1, 1, 1, 1, 1, 1]
     env = BacktestEnvWithSignals(df, cfg=cfg, signals=signals)
     env.reset()
 
@@ -76,7 +83,7 @@ def test_countdown_enables_trading():
 def test_signal_minus_one_forces_closure():
     df = make_df(6)
     cfg = make_cfg(n=1)
-    signals = [1, 1, -1, 0, 0, 0]
+    signals = [1, 1, -1, -1, -1, -1]
     env = BacktestEnvWithSignals(df, cfg=cfg, signals=signals)
     env.reset()
 


### PR DESCRIPTION
## Summary
- enforce that BacktestEnv accepts only -1 and 1 trading signals
- update BacktestEnvWithSignals tests to reflect binary signals and cover countdown behaviour

## Testing
- PYTHONPATH=. pytest tests/test_backtest_env_with_signals.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e2da0f84832e9389cab058ece280