### PR TITLE
Ensure BacktestEnvWithSignals zeroes state when trading is disabled

### DIFF
--- a/scr/backtest_env_with_signals.py
+++ b/scr/backtest_env_with_signals.py
@@ -80,6 +80,10 @@ class BacktestEnvWithSignals(BacktestEnv):
 
         self._finalize_countdown(current_signal)
 
+        if not self.can_trade:
+            obs = dict(obs)
+            obs["state"] = self._zero_state.copy()
+
         info = dict(info)
         info.update(
             signal=current_signal,

--- a/tests/test_backtest_env_with_signals.py
+++ b/tests/test_backtest_env_with_signals.py
@@ -102,3 +102,30 @@ def test_signal_minus_one_forces_closure():
     assert info["can_trade"] is False
     assert info["countdown"] == 0
 
+
+def test_state_zero_when_trading_disabled():
+    df = make_df(8)
+    cfg = make_cfg(n=2)
+    signals = [1, 1, 1, -1, -1, -1, -1, -1]
+    env = BacktestEnvWithSignals(df, cfg=cfg, signals=signals, ppo_true=True)
+
+    obs = env.reset()
+    assert np.allclose(obs["state"], 0.0)
+
+    obs, _, _, info = env.step(0)
+    assert info["can_trade"] is False
+    assert np.allclose(obs["state"], 0.0)
+
+    obs, _, _, info = env.step(0)
+    assert info["can_trade"] is True
+    assert not np.allclose(obs["state"], 0.0)
+
+    obs, _, _, info = env.step(0)
+    assert info["can_trade"] is True
+    assert env.position == 1
+    assert pytest.approx(1.0) == obs["state"][0]
+
+    obs, _, _, info = env.step(2)
+    assert info["can_trade"] is False
+    assert np.allclose(obs["state"], 0.0)
+


### PR DESCRIPTION
## Summary
- override the BacktestEnvWithSignals step observation so state is zeroed whenever trading remains forbidden
- add a regression test that checks state zeros while trading is disabled and reverts to the standard state once trading is allowed

## Testing
- PYTHONPATH=. pytest tests/test_backtest_env_with_signals.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b7bf27c0832eb0fa18a439a46118