### PR TITLE
Add shared interval alignment utility

### DIFF
--- a/scr/time_utils.py
+++ b/scr/time_utils.py
@@ -1,0 +1,35 @@
+"""Вспомогательные функции для работы с временными индексами."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+IntervalLike = pd.Index | np.ndarray | Iterable[pd.Timestamp]
+
+
+def align_intervals(index: pd.DatetimeIndex, interval: IntervalLike) -> pd.DatetimeIndex:
+    """Привести произвольный интервал к ``DatetimeIndex`` исходного индекса.
+
+    Функция конвертирует входной ``interval`` в ``DatetimeIndex``, выполняет
+    согласование часовых поясов с ``index`` и ограничивает интервал рамками
+    исходного индекса.
+    """
+
+    if not isinstance(index, pd.DatetimeIndex):
+        raise TypeError("index must be a pandas.DatetimeIndex")
+
+    seg = pd.DatetimeIndex(interval)
+
+    if index.tz is not None:
+        if seg.tz is None:
+            seg = seg.tz_localize(index.tz)
+        elif str(seg.tz) != str(index.tz):
+            seg = seg.tz_convert(index.tz)
+    elif seg.tz is not None:
+        seg = seg.tz_convert("UTC").tz_localize(None)
+
+    return seg.intersection(index)
+


### PR DESCRIPTION
## Summary
- add `scr/time_utils.align_intervals` helper for normalizing interval inputs against a base index
- reuse the helper in dataset builder, PPO training, and plotting utilities to remove duplicated logic
- keep validation index handling consistent across modules while supporting timezone-aware intervals

## Testing
- pytest test_run.py

------
https://chatgpt.com/codex/tasks/task_e_68d7eac1cbac832e87a88f443da027f0